### PR TITLE
Built-in functions

### DIFF
--- a/src/main/kotlin/compiler/Compiler.kt
+++ b/src/main/kotlin/compiler/Compiler.kt
@@ -42,7 +42,7 @@ object Compiler {
     fun eval(code: String): String {
         val result = compile(code, withDebug = true)
         when (result) {
-            is Result.Failure -> return "Compilation error: ${result.e} TOKENS:\n${Lexer(code).lex()}"
+            is Result.Failure -> return "Compilation error: ${result.e.stackTraceToString()} TOKENS:\n${Lexer(code).lex()}"
             is Result.Success -> {
                 try {
 

--- a/src/main/kotlin/compiler/ast/N_IDENTIFIER.kt
+++ b/src/main/kotlin/compiler/ast/N_IDENTIFIER.kt
@@ -100,7 +100,7 @@ class N_PROPREF(val left: N_EXPR, val right: N_EXPR): N_EXPR() {
 
 class N_FUNCREF(val left: N_EXPR, val right: N_EXPR, val args: List<N_EXPR>): N_EXPR() {
     override fun toText() = "$left.$right($args)"
-    override fun kids() = mutableListOf(left).apply { addAll(args) }
+    override fun kids() = mutableListOf(left, right).apply { addAll(args) }
 
     override fun identify() { (right as? N_IDENTIFIER)?.markAsFunc() }
 

--- a/src/main/kotlin/compiler/ast/N_IDENTIFIER.kt
+++ b/src/main/kotlin/compiler/ast/N_IDENTIFIER.kt
@@ -99,10 +99,10 @@ class N_PROPREF(val left: N_EXPR, val right: N_EXPR): N_EXPR() {
 }
 
 class N_FUNCREF(val left: N_EXPR, val right: N_EXPR, val args: List<N_EXPR>): N_EXPR() {
-    override fun toText() = "$left($args)"
+    override fun toText() = "$left.$right($args)"
     override fun kids() = mutableListOf(left).apply { addAll(args) }
 
-    override fun identify() { (left as? N_IDENTIFIER)?.markAsFunc() }
+    override fun identify() { (right as? N_IDENTIFIER)?.markAsFunc() }
 
     override fun code(coder: Coder) {
         args.forEach { it.code(coder) }

--- a/src/main/kotlin/value/VBool.kt
+++ b/src/main/kotlin/value/VBool.kt
@@ -20,10 +20,18 @@ data class VBool(val v: Boolean): Value() {
 
     override fun getProp(c: Context, name: String): Value? {
         when (name) {
-            "asInt" -> return VInt(if (v) 1 else 0)
-            "asString" -> return VString(asString())
+            "asInt" -> return propAsInt()
+            "asString" -> return propAsString()
         }
         return null
     }
+
+
+    // Custom props
+
+    private fun propAsInt() = VInt(if (v) 1 else 0)
+    private fun propAsString() = VString(asString())
+
+    // Custom funcs
 
 }

--- a/src/main/kotlin/value/VFloat.kt
+++ b/src/main/kotlin/value/VFloat.kt
@@ -1,6 +1,7 @@
 package com.dlfsystems.value
 
 import com.dlfsystems.vm.Context
+import kotlin.math.floor
 
 data class VFloat(val v: Float): Value() {
 
@@ -37,10 +38,20 @@ data class VFloat(val v: Float): Value() {
 
     override fun getProp(c: Context, name: String): Value? {
         when (name) {
-            "asInt" -> return VInt(v.toInt())
-            "asString" -> return VString(toString())
+            "asInt" -> return propAsInt()
+            "asString" -> return propAsString()
+            "floor" -> return propFloor()
         }
         return null
     }
+
+
+    // Custom props
+
+    private fun propAsInt() = VInt(v.toInt())
+    private fun propAsString() = VString(asString())
+    private fun propFloor() = VFloat(floor(v))
+
+    // Custom funcs
 
 }

--- a/src/main/kotlin/value/VFloat.kt
+++ b/src/main/kotlin/value/VFloat.kt
@@ -1,6 +1,7 @@
 package com.dlfsystems.value
 
 import com.dlfsystems.vm.Context
+import kotlin.math.ceil
 import kotlin.math.floor
 
 data class VFloat(val v: Float): Value() {
@@ -41,6 +42,7 @@ data class VFloat(val v: Float): Value() {
             "asInt" -> return propAsInt()
             "asString" -> return propAsString()
             "floor" -> return propFloor()
+            "ceil" -> return propCeil()
         }
         return null
     }
@@ -51,6 +53,7 @@ data class VFloat(val v: Float): Value() {
     private fun propAsInt() = VInt(v.toInt())
     private fun propAsString() = VString(asString())
     private fun propFloor() = VFloat(floor(v))
+    private fun propCeil() = VFloat(ceil(v))
 
     // Custom funcs
 

--- a/src/main/kotlin/value/VInt.kt
+++ b/src/main/kotlin/value/VInt.kt
@@ -37,10 +37,18 @@ data class VInt(val v: Int): Value() {
 
     override fun getProp(c: Context, name: String): Value? {
         when (name) {
-            "asFloat" -> return VFloat(v.toFloat())
-            "asString" -> return VString(toString())
+            "asFloat" -> return propAsFloat()
+            "asString" -> return propAsString()
         }
         return null
     }
+
+
+    // Custom props
+
+    private fun propAsFloat() = VFloat(v.toFloat())
+    private fun propAsString() = VString(asString())
+
+    // Custom funcs
 
 }

--- a/src/main/kotlin/value/VList.kt
+++ b/src/main/kotlin/value/VList.kt
@@ -80,6 +80,10 @@ data class VList(var v: MutableList<Value>): Value() {
 
     private fun funcJoin(args: List<Value>): Value {
         if (args.size > 1) fail(E_RANGE, "incorrect number of arguments")
-        return VString(v.joinToString(args[0].asString()) { it.asString() })
+        return VString(
+            v.joinToString(
+                if (args.isEmpty()) " " else args[0].asString()
+            ) { it.asString() }
+        )
     }
 }

--- a/src/main/kotlin/value/VList.kt
+++ b/src/main/kotlin/value/VList.kt
@@ -79,7 +79,7 @@ data class VList(var v: MutableList<Value>): Value() {
     // Custom funcs
 
     private fun funcJoin(args: List<Value>): Value {
-        if (args.size > 1) fail(E_RANGE, "incorrect number of arguments")
+        requireArgCount(args, 0, 1)
         return VString(
             v.joinToString(
                 if (args.isEmpty()) " " else args[0].asString()

--- a/src/main/kotlin/value/VList.kt
+++ b/src/main/kotlin/value/VList.kt
@@ -14,7 +14,9 @@ data class VList(var v: MutableList<Value>): Value() {
 
     override fun getProp(c: Context, name: String): Value? {
         when (name) {
-            "length" -> return VInt(v.size)
+            "length" -> return propSize()
+            "isEmpty" -> return propIsEmpty()
+            "isNotEmpty" -> return propIsNotEmpty()
         }
         return null
     }
@@ -60,4 +62,24 @@ data class VList(var v: MutableList<Value>): Value() {
         return false
     }
 
+    override fun callFunc(c: Context, name: String, args: List<Value>): Value? {
+        when (name) {
+            "join" -> return funcJoin(args)
+        }
+        return null
+    }
+
+
+    // Custom props
+
+    private fun propSize(): Value = VInt(v.size)
+    private fun propIsEmpty(): Value = VBool(v.isEmpty())
+    private fun propIsNotEmpty(): Value = VBool(v.isNotEmpty())
+
+    // Custom funcs
+
+    private fun funcJoin(args: List<Value>): Value {
+        if (args.size > 1) fail(E_RANGE, "incorrect number of arguments")
+        return VString(v.joinToString(args[0].asString()) { it.asString() })
+    }
 }

--- a/src/main/kotlin/value/VList.kt
+++ b/src/main/kotlin/value/VList.kt
@@ -67,6 +67,8 @@ data class VList(var v: MutableList<Value>): Value() {
             "join" -> return funcJoin(args)
             "push" -> return funcPush(args)
             "pop" -> return funcPop(args)
+            "contains" -> return funcContains(args)
+            "indexOf" -> return funcIndexOf(args)
         }
         return null
     }
@@ -99,5 +101,15 @@ data class VList(var v: MutableList<Value>): Value() {
         requireArgCount(args, 0, 0)
         if (v.isEmpty()) fail(E_RANGE, "cannot pop empty list")
         return v.removeAt(0)
+    }
+
+    private fun funcContains(args: List<Value>): Value {
+        requireArgCount(args, 1, 1)
+        return VBool(v.contains(args[0]))
+    }
+
+    private fun funcIndexOf(args: List<Value>): Value {
+        requireArgCount(args, 1, 1)
+        return if (v.contains(args[0])) VInt(v.indexOf(args[0])) else VInt(-1)
     }
 }

--- a/src/main/kotlin/value/VList.kt
+++ b/src/main/kotlin/value/VList.kt
@@ -65,6 +65,8 @@ data class VList(var v: MutableList<Value>): Value() {
     override fun callFunc(c: Context, name: String, args: List<Value>): Value? {
         when (name) {
             "join" -> return funcJoin(args)
+            "push" -> return funcPush(args)
+            "pop" -> return funcPop(args)
         }
         return null
     }
@@ -85,5 +87,17 @@ data class VList(var v: MutableList<Value>): Value() {
                 if (args.isEmpty()) " " else args[0].asString()
             ) { it.asString() }
         )
+    }
+
+    private fun funcPush(args: List<Value>): Value {
+        requireArgCount(args, 1, 1)
+        v.add(0, args[0])
+        return VVoid()
+    }
+
+    private fun funcPop(args: List<Value>): Value {
+        requireArgCount(args, 0, 0)
+        if (v.isEmpty()) fail(E_RANGE, "cannot pop empty list")
+        return v.removeAt(0)
     }
 }

--- a/src/main/kotlin/value/VMap.kt
+++ b/src/main/kotlin/value/VMap.kt
@@ -14,9 +14,9 @@ data class VMap(val v: MutableMap<String, Value>): Value() {
 
     override fun getProp(c: Context, name: String): Value? {
         when (name) {
-            "length" -> return VInt(v.size)
-            "keys" -> return VList(realKeys.values.toMutableList())
-            "values" -> return VList(v.values.toMutableList())
+            "length" -> return propLength()
+            "keys" -> return propKeys()
+            "values" -> return propValues()
         }
         return null
     }
@@ -53,4 +53,14 @@ data class VMap(val v: MutableMap<String, Value>): Value() {
             return VMap(map).apply { realKeys = reals }
         }
     }
+
+
+    // Custom props
+
+    private fun propLength() = VInt(v.size)
+    private fun propKeys() = VList(realKeys.values.toMutableList())
+    private fun propValues() = VList(v.values.toMutableList())
+
+    // Custom funcs
+
 }

--- a/src/main/kotlin/value/VMap.kt
+++ b/src/main/kotlin/value/VMap.kt
@@ -37,6 +37,14 @@ data class VMap(val v: MutableMap<String, Value>): Value() {
         return false
     }
 
+    override fun callFunc(c: Context, name: String, args: List<Value>): Value? {
+        when (name) {
+            "containsKey" -> return funcContainsKey(args)
+            "containsValue" -> return funcContainsValue(args)
+        }
+        return null
+    }
+
     // We make new VMaps statically so we can use a constructed string as the map key,
     // instead of the Value object itself.  We save the original key so it can be
     // returned by this.keys.
@@ -63,4 +71,13 @@ data class VMap(val v: MutableMap<String, Value>): Value() {
 
     // Custom funcs
 
+    private fun funcContainsKey(args: List<Value>): Value {
+        requireArgCount(args, 1, 1)
+        return VBool(realKeys.containsValue(args[0]))
+    }
+
+    private fun funcContainsValue(args: List<Value>): Value {
+        requireArgCount(args, 1, 1)
+        return VBool(v.containsValue(args[0]))
+    }
 }

--- a/src/main/kotlin/value/VObj.kt
+++ b/src/main/kotlin/value/VObj.kt
@@ -19,7 +19,7 @@ data class VObj(val v: UUID?): Value() {
 
     override fun getProp(c: Context, name: String): Value? {
         when (name) {
-            "asString" -> return VString(toString())
+            "asString" -> return propAsString()
         }
         return null
     }
@@ -27,5 +27,12 @@ data class VObj(val v: UUID?): Value() {
     override fun setProp(c: Context, name: String, value: Value): Boolean {
         return false
     }
+
+
+    // Custom props
+
+    private fun propAsString() = VString(toString())
+
+    // Custom funcs
 
 }

--- a/src/main/kotlin/value/VString.kt
+++ b/src/main/kotlin/value/VString.kt
@@ -27,6 +27,8 @@ data class VString(var v: String): Value() {
             "length" -> return propLength()
             "asInt" -> return propAsInt()
             "asFloat" -> return propAsFloat()
+            "isEmpty" -> return propIsEmpty()
+            "isNotEmpty" -> return propIsNotEmpty()
         }
         return null
     }
@@ -77,6 +79,10 @@ data class VString(var v: String): Value() {
     override fun callFunc(c: Context, name: String, args: List<Value>): Value? {
         when (name) {
             "split" -> return funcSplit(args)
+            "contains" -> return funcContains(args)
+            "startsWith" -> return funcStartsWith(args)
+            "endsWith" -> return funcEndsWith(args)
+            "indexOf" -> return funcIndexOf(args)
         }
         return null
     }
@@ -87,15 +93,38 @@ data class VString(var v: String): Value() {
     private fun propLength() = VInt(v.length)
     private fun propAsInt() = VInt(v.toInt())
     private fun propAsFloat() = VFloat(v.toFloat())
+    private fun propIsEmpty() = VBool(v.isEmpty())
+    private fun propIsNotEmpty() = VBool(v.isNotEmpty())
 
     // Custom funcs
 
     private fun funcSplit(args: List<Value>): Value {
-        if (args.size > 1) fail(E_RANGE, "incorrect number of arguments")
+        requireArgCount(args, 0, 1)
         return VList(
             v.split(
                 if (args.isEmpty()) " " else args[0].asString()
             ).map { VString(it) }.toMutableList()
         )
+    }
+
+    private fun funcContains(args: List<Value>): Value {
+        requireArgCount(args, 1, 1)
+        return VBool(v.contains(args[0].asString()))
+    }
+
+    private fun funcStartsWith(args: List<Value>): Value {
+        requireArgCount(args, 1, 1)
+        return VBool(v.startsWith(args[0].asString()))
+    }
+
+    private fun funcEndsWith(args: List<Value>): Value {
+        requireArgCount(args, 1, 1)
+        return VBool(v.endsWith(args[0].asString()))
+    }
+
+    private fun funcIndexOf(args: List<Value>): Value {
+        requireArgCount(args, 1, 1)
+        val s = args[0].asString()
+        if (v.contains(s)) return VInt(v.indexOf(s)) else return VInt(-1)
     }
 }

--- a/src/main/kotlin/value/VString.kt
+++ b/src/main/kotlin/value/VString.kt
@@ -24,9 +24,9 @@ data class VString(var v: String): Value() {
 
     override fun getProp(c: Context, name: String): Value? {
         when (name) {
-            "length" -> return VInt(v.length)
-            "asInt" -> return VInt(v.toInt())
-            "asFloat" -> return VFloat(v.toFloat())
+            "length" -> return propLength()
+            "asInt" -> return propAsInt()
+            "asFloat" -> return propAsFloat()
         }
         return null
     }
@@ -74,4 +74,28 @@ data class VString(var v: String): Value() {
         return false
     }
 
+    override fun callFunc(c: Context, name: String, args: List<Value>): Value? {
+        when (name) {
+            "split" -> return funcSplit(args)
+        }
+        return null
+    }
+
+
+    // Custom props
+
+    private fun propLength() = VInt(v.length)
+    private fun propAsInt() = VInt(v.toInt())
+    private fun propAsFloat() = VFloat(v.toFloat())
+
+    // Custom funcs
+
+    private fun funcSplit(args: List<Value>): Value {
+        if (args.size > 1) fail(E_RANGE, "incorrect number of arguments")
+        return VList(
+            v.split(
+                if (args.isEmpty()) " " else args[0].asString()
+            ).map { VString(it) }.toMutableList()
+        )
+    }
 }

--- a/src/main/kotlin/value/VString.kt
+++ b/src/main/kotlin/value/VString.kt
@@ -125,6 +125,6 @@ data class VString(var v: String): Value() {
     private fun funcIndexOf(args: List<Value>): Value {
         requireArgCount(args, 1, 1)
         val s = args[0].asString()
-        if (v.contains(s)) return VInt(v.indexOf(s)) else return VInt(-1)
+        return if (v.contains(s)) VInt(v.indexOf(s)) else VInt(-1)
     }
 }

--- a/src/main/kotlin/value/VTrait.kt
+++ b/src/main/kotlin/value/VTrait.kt
@@ -20,9 +20,7 @@ data class VTrait(val v: UUID?): Value() {
     override fun getProp(c: Context, name: String): Value? {
         val trait = getTrait(c)
         when (name) {
-            "asString" -> v?.also { v ->
-                return VString("$" + c.world?.getTrait(v)?.name)
-            } ?: return VString(toString())
+            "asString" -> return propAsString(c)
         }
         return trait?.getProp(c, name)
     }
@@ -31,5 +29,14 @@ data class VTrait(val v: UUID?): Value() {
         val trait = getTrait(c)
         return trait?.setProp(c, name, value) ?: false
     }
+
+
+    // Custom props
+
+    private fun propAsString(c: Context) = v?.let { v ->
+        VString("$" + c.world.getTrait(v)?.name)
+    } ?: VString(asString())
+
+    // Custom funcs
 
 }

--- a/src/main/kotlin/value/VVoid.kt
+++ b/src/main/kotlin/value/VVoid.kt
@@ -13,9 +13,16 @@ data class VVoid(val v: Unit = Unit): Value() {
 
     override fun getProp(c: Context, name: String): Value? {
         when (name) {
-            "asString" -> return VString(toString())
+            "asString" -> return propAsString()
         }
         return null
     }
+
+
+    // Custom props
+
+    private fun propAsString() = VString(asString())
+
+    // Custom funcs
 
 }

--- a/src/main/kotlin/value/Value.kt
+++ b/src/main/kotlin/value/Value.kt
@@ -9,7 +9,12 @@ sealed class Value {
     enum class Type { VOID, BOOL, INT, FLOAT, STRING, LIST, MAP, OBJ, TRAIT }
     abstract val type: Type
 
+    // utility func for throwing a runtime exception
     fun fail(type: VMException.Type, m: String) { throw VMException(type, m, 0, 0) } // TODO: get line+char here somehow
+    // utility func for throwing E_RANGE on incorrect arg count
+    fun requireArgCount(args: List<Value>, min: Int, max: Int) {
+        if (args.size < min || args.size > max) fail(VMException.Type.E_RANGE, "incorrect number of args")
+    }
 
     // String equivalent for use as a map key.  Null if this value can't be a map key.
     open fun asMapKey(): String? = null

--- a/src/main/kotlin/value/Value.kt
+++ b/src/main/kotlin/value/Value.kt
@@ -46,4 +46,7 @@ sealed class Value {
     open fun getRange(c: Context, from: Value, to: Value): Value? = null
     open fun setIndex(c: Context, index: Value, value: Value): Boolean = false
     open fun setRange(c: Context, from: Value, to: Value, value: Value): Boolean = false
+
+    // Call a func on this type and return its value.  Null raises E_FUNCNF.
+    open fun callFunc(c: Context, name: String, args: List<Value>): Value? = null
 }

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -125,12 +125,17 @@ class VM(val code: List<VMWord> = listOf()) {
                 // Func ops
 
                 O_CALL -> {
-                    c.ticksLeft = ticksLeft
-                    // get func location, name, args
-                    // put our frame on the callstack
-                    // call the func for return val
-                    // pop our frame off the callstack
-                    // push return val
+                    val argCount = next().intFromV
+                    val (a2, a1) = popTwo()
+                    val args = mutableListOf<Value>()
+                    repeat(argCount) { args.add(pop()) }
+                    if (a2 is VString) {
+                        c.ticksLeft = ticksLeft
+                        // TODO: put our frame on the callstack (opt: skip this for builtin type funcs?)
+                        a1.callFunc(c, a2.v, args)?.also { push(it) }
+                            ?: fail(E_FUNCNF, "func not found")
+                    } else fail(E_FUNCNF, "func name must be string")
+                    // TODO: pop our frame off the callstack
                     ticksLeft = c.ticksLeft
                 }
 

--- a/src/main/kotlin/vm/VMException.kt
+++ b/src/main/kotlin/vm/VMException.kt
@@ -16,6 +16,9 @@ class VMException(c: Type, m: String, lineNum: Int, charNum: Int): Exception("$c
         // Trait not found
         E_TRAITNF,
 
+        // Func not found
+        E_FUNCNF,
+
         // List or map accessed out of range
         E_RANGE,
 

--- a/src/main/kotlin/world/Obj.kt
+++ b/src/main/kotlin/world/Obj.kt
@@ -14,14 +14,4 @@ class Obj {
 
     val traits: MutableList<UUID> = mutableListOf()
 
-    fun callFunc(c: Context, funcName: String): Value? {
-        c.vThis = vThis
-        traits.forEach { id ->
-            c.getTrait(id)?.also { trait ->
-                trait.callFunc(c, funcName)?.also { return it }
-            }
-        }
-        return null
-    }
-
 }

--- a/src/main/kotlin/world/trait/SysTrait.kt
+++ b/src/main/kotlin/world/trait/SysTrait.kt
@@ -21,11 +21,4 @@ class SysTrait : Trait("sys") {
         return super.getProp(c, name)
     }
 
-    override fun callFunc(c: Context, name: String): Value? {
-        when (name) {
-
-        }
-        return super.callFunc(c, name)
-    }
-
 }

--- a/src/main/kotlin/world/trait/Trait.kt
+++ b/src/main/kotlin/world/trait/Trait.kt
@@ -22,15 +22,10 @@ open class Trait(val name: String) {
         }
     }
 
-    open fun callFunc(c: Context, name: String): Value? = funcs[name]?.execute(c)
-
     open fun getProp(c: Context, name: String): Value? = props.getOrDefault(name, null)
     open fun setProp(c: Context, name: String, value: Value): Boolean {
         props[name] = value
         return true
-    }
-    open fun setPropIndex(c: Context, name: String, index: Value, value: Value): Boolean {
-        return props[name]!!.setIndex(c, index, value)
     }
 
 }


### PR DESCRIPTION
Adds function calls as an expression type.  Currently only calling built-in functions on Value types is supported; calling funcs on objects/traits will come later.

The parser was already parsing an N_FUNCALL node so no changes were needed there; the meat here is in VM.execute() handling the O_CALL opcode and the subsequent call to Value.callFunc().

I expect that calling user-defined funcs will happen in VObj.callFunc() (and VTrait.callFunc() for static trait funcs), which is where we'll do our dynamic dispatch.

Unrelated changes: I moved all built-in prop calls to their own functions and cleaned up formatting on the other Value classes.  I also deleted some stubs in other classes relating to funcalls to have a clean slate.

```
foo = ["a", "b", "c", "d", "e"]
joined = foo.join() + " f g h"
ele = joined.split()
return ele


RESULT:
["a", "b", "c", "d", "e", "f", "g", "h"]
```


