### PR TITLE
Opcode optimizer

### DIFF
--- a/src/main/kotlin/compiler/Coder.kt
+++ b/src/main/kotlin/compiler/Coder.kt
@@ -129,25 +129,25 @@ class Coder(val ast: Node) {
                 consume(O_NEGATE, O_NEGATE)?.also { }
 
                 // SETVAR GETVAR => SETGETVAR
-                    ?: consume(O_SETVAR, null, O_GETVAR, null) { args ->
-                        args[0].isInt() && args[1].isInt(args[0].intFromV)
-                    }?.also { args ->
-                        code(O_SETGETVAR)
-                        value(args[0].value!!)
-                    }
+                ?: consume(O_SETVAR, null, O_GETVAR, null) { args ->
+                    args[0].isInt() && args[1].isInt(args[0].intFromV)
+                }?.also { args ->
+                    code(O_SETGETVAR)
+                    value(args[0].value!!)
+                }
 
-                    // O_VAL 0 O_CMP_xx => O_CMP_xxZ
-                    ?: consume(O_VAL, null, O_CMP_EQ) { args -> args[0].isInt(0) }?.also { code(O_CMP_EQZ) }
-                    ?: consume(O_VAL, null, O_CMP_GT) { args -> args[0].isInt(0) }?.also { code(O_CMP_GTZ) }
-                    ?: consume(O_VAL, null, O_CMP_GE) { args -> args[0].isInt(0) }?.also { code(O_CMP_GEZ) }
-                    ?: consume(O_VAL, null, O_CMP_LT) { args -> args[0].isInt(0) }?.also { code(O_CMP_LTZ) }
-                    ?: consume(O_VAL, null, O_CMP_LE) { args -> args[0].isInt(0) }?.also { code(O_CMP_LEZ) }
+                // O_VAL 0 O_CMP_xx => O_CMP_xxZ
+                ?: consume(O_VAL, null, O_CMP_EQ) { args -> args[0].isInt(0) }?.also { code(O_CMP_EQZ) }
+                ?: consume(O_VAL, null, O_CMP_GT) { args -> args[0].isInt(0) }?.also { code(O_CMP_GTZ) }
+                ?: consume(O_VAL, null, O_CMP_GE) { args -> args[0].isInt(0) }?.also { code(O_CMP_GEZ) }
+                ?: consume(O_VAL, null, O_CMP_LT) { args -> args[0].isInt(0) }?.also { code(O_CMP_LTZ) }
+                ?: consume(O_VAL, null, O_CMP_LE) { args -> args[0].isInt(0) }?.also { code(O_CMP_LEZ) }
 
 
-                    // If nothing matched, copy and continue
-                    ?: run {
-                        mem.add(source[pc++])
-                    }
+                // If nothing matched, copy and continue
+                ?: run {
+                    mem.add(source[pc++])
+                }
             }
 
             // Replace all jump dests

--- a/src/main/kotlin/compiler/Coder.kt
+++ b/src/main/kotlin/compiler/Coder.kt
@@ -22,6 +22,9 @@ class Coder(val ast: Node) {
     // Nodes will then call Coder.code() and Coder.value() to output their compiled code.
     fun generate() {
         ast.code(this)
+    }
+
+    fun postOptimize() {
         Optimizer.postOptimize(mem)
         mem = Optimizer.mem
     }

--- a/src/main/kotlin/compiler/Compiler.kt
+++ b/src/main/kotlin/compiler/Compiler.kt
@@ -27,7 +27,10 @@ object Compiler {
             // Stage 3: Find variables and optimize tree nodes.
             val ast = Shaker(parser.parse()).shake()
             // Stage 4: Generate VM opcodes.
-            val coder = Coder(ast).apply { generate() }
+            val coder = Coder(ast).apply {
+                generate()
+                postOptimize()
+            }
 
             return if (withDebug)
                 Result.Success(coder.mem, tokens, ast, coder.dumpText())

--- a/src/main/kotlin/vm/Opcode.kt
+++ b/src/main/kotlin/vm/Opcode.kt
@@ -35,7 +35,7 @@ enum class Opcode(val argCount: Int = 0) {
     // Throw E_USER with pop0 as message.
     O_FAIL,
 
-    // TODO
+    // Call function with arg1 stack args.
     O_CALL(1),
 
     // Push variable with ID arg1.
@@ -43,9 +43,6 @@ enum class Opcode(val argCount: Int = 0) {
 
     // Set variable with ID arg1 to value pop0.
     O_SETVAR(1), // variable ID to store
-
-    // SETVAR then GETVAR.
-    O_SETGETVAR(1),
 
     // Increment/decrement variable with ID arg1.
     O_INCVAR(1), // variable ID to inc
@@ -90,5 +87,18 @@ enum class Opcode(val argCount: Int = 0) {
     O_DIV,
     O_POWER,
     O_MODULUS,
+
+
+    // Optimizer instructions
+
+    // SETVAR then GETVAR.
+    O_SETGETVAR(1),
+
+    // Compare pop0 to zero.
+    O_CMP_EQZ,
+    O_CMP_GTZ,
+    O_CMP_GEZ,
+    O_CMP_LTZ,
+    O_CMP_LEZ,
 
 }

--- a/src/main/kotlin/vm/Opcode.kt
+++ b/src/main/kotlin/vm/Opcode.kt
@@ -44,6 +44,9 @@ enum class Opcode(val argCount: Int = 0) {
     // Set variable with ID arg1 to value pop0.
     O_SETVAR(1), // variable ID to store
 
+    // SETVAR then GETVAR.
+    O_SETGETVAR(1),
+
     // Increment/decrement variable with ID arg1.
     O_INCVAR(1), // variable ID to inc
     O_DECVAR(1), // variable ID to dec

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -228,6 +228,11 @@ class VM(val code: List<VMWord> = listOf()) {
                         else -> { }
                     }
                 }
+                O_CMP_EQZ -> { push(VBool(pop().cmpEq(VInt(0)))) }
+                O_CMP_GTZ -> { push(VBool(pop().cmpGt(VInt(0)))) }
+                O_CMP_GEZ -> { push(VBool(pop().cmpGe(VInt(0)))) }
+                O_CMP_LTZ -> { push(VBool(pop().cmpLt(VInt(0)))) }
+                O_CMP_LEZ -> { push(VBool(pop().cmpLe(VInt(0)))) }
 
                 // Math ops
 
@@ -268,6 +273,12 @@ class VMWord(
     fun fillAddress(newAddress: Int) { address = newAddress }
 
     override fun toString() = opcode?.toString() ?: value?.toString() ?: address?.let { "<$it>" } ?: "!!NULL!!"
+
+    fun isInt(equals: Int? = null): Boolean {
+        if (value !is VInt) return false
+        if (equals == null) return true
+        return (value.v == equals)
+    }
 
     // If this is known to be an int opcode arg, just get the int value.
     val intFromV: Int

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -146,6 +146,9 @@ class VM(val code: List<VMWord> = listOf()) {
                     val a1 = pop()
                     variables[varID] = a1
                 }
+                O_SETGETVAR -> {
+                    variables[next().intFromV] = stack.peek()
+                }
                 O_INCVAR, O_DECVAR -> {
                     val varID = next().intFromV
                     variables[varID]?.also {


### PR DESCRIPTION
Adds an optimizing pass after generation of VM opcodes.  This came out of a special case I had in Coder, which prevented two O_NEGATEs from being written in a row.  I made a generalized DSL mechanism in Coder.Optimizer which lets us express sequences of opcode matches, and replace them with different sequences.

Sequences we optimize in this PR:

- O_NEGATE, O_NEGATE -> replace with nothing
- O_SETVAR x, O_GETVAR x -> O_SETGETVAR x
- O_VAL 0, CMP_xx -> O_CMP_xxZ  (compare with literal zero)

The general idea is that as we notice common sequences of opcodes (such as the three above, which I noticed in real code), we can create combo opcodes that execute all the work in one go, and have Coder.Optimizer swap those after the AST generates code.

Philosophically -- we have a CPU with a slow instruction pipeline, and a very big die size.  If we want to squeeze performance later, it behooves us to have a way to aggressively combine simple opcodes into bigger ones, CISC style.
