### PR TITLE
Allow LIST or MAP to be added together

### DIFF
--- a/src/main/kotlin/value/VFloat.kt
+++ b/src/main/kotlin/value/VFloat.kt
@@ -10,7 +10,6 @@ data class VFloat(val v: Float): Value() {
 
     override fun toString() = v.toString()
     override fun asString() = v.toString()
-    override fun asMapKey() = "$v FLOAT"
 
     override fun isZero() = v == 0F
 

--- a/src/main/kotlin/value/VInt.kt
+++ b/src/main/kotlin/value/VInt.kt
@@ -8,7 +8,6 @@ data class VInt(val v: Int): Value() {
 
     override fun toString() = v.toString()
     override fun asString() = v.toString()
-    override fun asMapKey() = "$v INT"
 
     override fun isZero() = v == 0
 

--- a/src/main/kotlin/value/VList.kt
+++ b/src/main/kotlin/value/VList.kt
@@ -12,6 +12,11 @@ data class VList(var v: MutableList<Value>): Value() {
 
     override fun iterableSize() = v.size
 
+    override fun plus(a2: Value) = when (a2) {
+        is VList -> VList(v.toMutableList().apply { addAll(a2.v) })
+        else -> null
+    }
+
     override fun getProp(c: Context, name: String): Value? {
         when (name) {
             "length" -> return propSize()

--- a/src/main/kotlin/value/VMap.kt
+++ b/src/main/kotlin/value/VMap.kt
@@ -1,25 +1,18 @@
 package com.dlfsystems.value
 
 import com.dlfsystems.vm.Context
-import com.dlfsystems.vm.VMException
 import com.dlfsystems.vm.VMException.Type.*
 
-data class VMap(val v: MutableMap<String, Value>): Value() {
-
-    var realKeys = mutableMapOf<String, Value>()
+data class VMap(val v: MutableMap<Value, Value>): Value() {
 
     override val type = Type.MAP
     override fun toString() = "[${v.entries.joinToString()}]"
     override fun asString() = v.entries.joinToString(", ")
 
-    override fun contains(a2: Value) = realKeys.values.contains(a2)
+    override fun contains(a2: Value) = v.containsKey(a2)
 
     override fun plus(a2: Value) = when (a2) {
-        is VMap -> make(mutableMapOf<Value, Value>().apply {
-                realKeys.keys.forEach { set(realKeys[it]!!, v[it]!!) }
-                a2.realKeys.keys.forEach { set(a2.realKeys[it]!!, a2.v[it]!!)}
-            }
-        )
+        is VMap -> VMap((v + a2.v).toMutableMap())
         else -> null
     }
 
@@ -32,20 +25,16 @@ data class VMap(val v: MutableMap<String, Value>): Value() {
         return null
     }
 
-    override fun getIndex(c: Context, index: Value): Value? {
-        index.asMapKey()?.also {
-            if (v.containsKey(it)) return v[it]
-            else fail(E_RANGE, "no map entry $index")
-        }
+    override fun getIndex(c: Context, i: Value): Value? {
+        if (v.containsKey(i)) return v[i]
+        else fail(E_RANGE, "no map entry $i")
         return null
     }
 
-    override fun setIndex(c: Context, index: Value, value: Value): Boolean {
-        index.asMapKey()?.also {
-            realKeys[it] = index
-            v[it] = value
-        }
-        return false
+    override fun setIndex(c: Context, i: Value, value: Value): Boolean {
+        if (i.type !in keyTypes) fail(E_TYPE, "${i.type} cannot be map key")
+        v[i] = value
+        return true
     }
 
     override fun callFunc(c: Context, name: String, args: List<Value>): Value? {
@@ -56,39 +45,26 @@ data class VMap(val v: MutableMap<String, Value>): Value() {
         return null
     }
 
-    // We make new VMaps statically so we can use a constructed string as the map key,
-    // instead of the Value object itself.  We save the original key so it can be
-    // returned by this.keys.
-    companion object {
-        fun make(v: Map<Value, Value>): VMap {
-            val reals = mutableMapOf<String, Value>()
-            val map = mutableMapOf<String, Value>()
-            v.keys.forEach { key ->
-                key.asMapKey()?.also {
-                    reals.put(it, key)
-                    map.put(it, v[key]!!)
-                } ?: throw VMException(E_TYPE, "${key.type} cannot be map key", 0, 0) // TODO: get real line+char
-            }
-            return VMap(map).apply { realKeys = reals }
-        }
-    }
-
-
     // Custom props
 
     private fun propLength() = VInt(v.size)
-    private fun propKeys() = VList(realKeys.values.toMutableList())
+    private fun propKeys() = VList(v.keys.toMutableList())
     private fun propValues() = VList(v.values.toMutableList())
 
     // Custom funcs
 
     private fun funcContainsKey(args: List<Value>): Value {
         requireArgCount(args, 1, 1)
-        return VBool(realKeys.containsValue(args[0]))
+        return VBool(v.containsKey(args[0]))
     }
 
     private fun funcContainsValue(args: List<Value>): Value {
         requireArgCount(args, 1, 1)
         return VBool(v.containsValue(args[0]))
+    }
+
+
+    companion object {
+        val keyTypes = listOf(Type.STRING, Type.INT, Type.OBJ, Type.TRAIT)
     }
 }

--- a/src/main/kotlin/value/VMap.kt
+++ b/src/main/kotlin/value/VMap.kt
@@ -12,6 +12,15 @@ data class VMap(val v: MutableMap<String, Value>): Value() {
     override fun toString() = "[${v.entries.joinToString()}]"
     override fun asString() = v.entries.joinToString(", ")
 
+    override fun plus(a2: Value) = when (a2) {
+        is VMap -> make(mutableMapOf<Value, Value>().apply {
+                realKeys.keys.forEach { set(realKeys[it]!!, v[it]!!) }
+                a2.realKeys.keys.forEach { set(a2.realKeys[it]!!, a2.v[it]!!)}
+            }
+        )
+        else -> null
+    }
+
     override fun getProp(c: Context, name: String): Value? {
         when (name) {
             "length" -> return propLength()

--- a/src/main/kotlin/value/VObj.kt
+++ b/src/main/kotlin/value/VObj.kt
@@ -9,7 +9,6 @@ data class VObj(val v: UUID?): Value() {
 
     override fun toString() = "#$v"
     override fun asString() = "OBJ" // TODO: use name from passed context?
-    override fun asMapKey() = "$v OBJ"
 
     override fun isTrue() = v != null
 

--- a/src/main/kotlin/value/VString.kt
+++ b/src/main/kotlin/value/VString.kt
@@ -9,7 +9,6 @@ data class VString(var v: String): Value() {
 
     override fun toString() = "\"$v\""
     override fun asString() = v
-    override fun asMapKey() = v
 
     override fun iterableSize() = v.length
 

--- a/src/main/kotlin/value/VTrait.kt
+++ b/src/main/kotlin/value/VTrait.kt
@@ -11,7 +11,6 @@ data class VTrait(val v: UUID?): Value() {
 
     override fun toString() = "\$$v"
     override fun asString() = "\$TRAIT" // TODO: get from context
-    override fun asMapKey() = "$v TRAIT"
 
     override fun isTrue() = v != null
 

--- a/src/main/kotlin/value/Value.kt
+++ b/src/main/kotlin/value/Value.kt
@@ -16,8 +16,6 @@ sealed class Value {
         if (args.size < min || args.size > max) fail(VMException.Type.E_RANGE, "incorrect number of args")
     }
 
-    // String equivalent for use as a map key.  Null if this value can't be a map key.
-    open fun asMapKey(): String? = null
     // String equivalent when added to a string.
     open fun asString(): String = "VALUE"
 

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -76,7 +76,7 @@ class VM(val code: List<VMWord> = listOf()) {
                     val count = next().intFromV
                     val entries = mutableMapOf<Value, Value>()
                     repeat(count) { entries.put(pop(), pop()) }
-                    push(VMap.make(entries))
+                    push(VMap(entries))
                 }
                 O_GETI -> {
                     val (a2, a1) = popTwo()


### PR DESCRIPTION
To add this we just override Value.plus(Value) on VList / VMap.  

The VList version uses .toMutableMap() to ensure we don't change the source list (demonstrated below).

The VMap version is a little trickier, because VMap uses a substitute string key for the internal map.  That whole scheme may be a bad idea; I originally did it to avoid problems with non-scalar key types but now I think there's just no reason to support that at all, so maybe I should remove it here and now.


LIST test.  Although not shown below, note this will add duplicates if present (i.e. it's not treated as a set).

```
foo = ["a", "b", "c"]
bar = [1, 2, 3]
baz = foo + bar
return "foo: $foo bar: $bar baz: $baz"

RESULT:
"foo: "a", "b", "c" bar: 1, 2, 3 baz: "a", "b", "c", 1, 2, 3"
```

MAP test.  By a map's nature, this will NOT add duplicate keys, as shown below, but will update the key's value.

```
foo = ["dick": 12, "balls": 74, "nuts": 33]
bar = ["mel": 52, "dan": 51, "balls": "REPLACED"]
baz = foo + bar
return "foo: $foo // bar: $bar // baz: $baz"

RESULT:
"foo: nuts=33, balls=74, dick=12 // bar: balls="REPLACED", dan=51, mel=52 // baz: nuts=33, balls="REPLACED", dick=12, dan=51, mel=52"
```
