### PR TITLE
Add 'in' comparison operator

### DIFF
--- a/src/main/kotlin/compiler/Parser.kt
+++ b/src/main/kotlin/compiler/Parser.kt
@@ -253,7 +253,7 @@ class Parser(inputTokens: List<Token>) {
 
     // Parse: <expr> ? <expr> : <expr>
     private fun pConditional(): N_EXPR? {
-        val next = this::pEquals
+        val next = this::pIn
         val left = next() ?: return null
         consume(T_QUESTION)?.also {
             next()?.also { mid ->
@@ -263,6 +263,18 @@ class Parser(inputTokens: List<Token>) {
                     } ?: fail("incomplete conditional")
                 } ?: fail("missing colon in conditional")
             } ?: fail("incomplete condition")
+        }
+        return left
+    }
+
+    // Parse: <expr> in <expr>
+    private fun pIn(): N_EXPR? {
+        val next = this::pEquals
+        var left = next() ?: return null
+        consume(T_IN)?.also {
+            next()?.also { right ->
+                left = node(N_CMP_IN(left, right))
+            }
         }
         return left
     }

--- a/src/main/kotlin/compiler/Parser.kt
+++ b/src/main/kotlin/compiler/Parser.kt
@@ -273,7 +273,7 @@ class Parser(inputTokens: List<Token>) {
         var left = next() ?: return null
         consume(T_IN)?.also {
             next()?.also { right ->
-                left = node(N_CMP_IN(left, right))
+                left = node(N_IN(left, right))
             }
         }
         return left

--- a/src/main/kotlin/compiler/ast/N_BINOP.kt
+++ b/src/main/kotlin/compiler/ast/N_BINOP.kt
@@ -32,3 +32,4 @@ class N_CMP_GT(left: N_EXPR, right: N_EXPR): N_BINOP(">", left, right, listOf(O_
 class N_CMP_LT(left: N_EXPR, right: N_EXPR): N_BINOP("<", left, right, listOf(O_CMP_LT))
 class N_CMP_GE(left: N_EXPR, right: N_EXPR): N_BINOP(">=", left, right, listOf(O_CMP_GE))
 class N_CMP_LE(left: N_EXPR, right: N_EXPR): N_BINOP("<=", left, right, listOf(O_CMP_LE))
+class N_CMP_IN(left: N_EXPR, right: N_EXPR): N_BINOP("in", left, right, listOf(O_CMP_IN))

--- a/src/main/kotlin/compiler/ast/N_BINOP.kt
+++ b/src/main/kotlin/compiler/ast/N_BINOP.kt
@@ -25,6 +25,7 @@ class N_POWER(left: N_EXPR, right: N_EXPR): N_BINOP("^", left, right, listOf(O_P
 class N_MODULUS(left: N_EXPR, right: N_EXPR): N_BINOP("%", left, right, listOf(O_MODULUS))
 class N_AND(left: N_EXPR, right: N_EXPR): N_BINOP("&&", left, right, listOf(O_AND))
 class N_OR(left: N_EXPR, right: N_EXPR): N_BINOP("||", left, right, listOf(O_OR))
+class N_IN(left: N_EXPR, right: N_EXPR): N_BINOP("in", left, right, listOf(O_IN))
 
 class N_CMP_EQ(left: N_EXPR, right: N_EXPR): N_BINOP("==", left, right, listOf(O_CMP_EQ))
 class N_CMP_NEQ(left: N_EXPR, right: N_EXPR): N_BINOP("!=", left, right, listOf(O_CMP_EQ, O_NEGATE))
@@ -32,4 +33,3 @@ class N_CMP_GT(left: N_EXPR, right: N_EXPR): N_BINOP(">", left, right, listOf(O_
 class N_CMP_LT(left: N_EXPR, right: N_EXPR): N_BINOP("<", left, right, listOf(O_CMP_LT))
 class N_CMP_GE(left: N_EXPR, right: N_EXPR): N_BINOP(">=", left, right, listOf(O_CMP_GE))
 class N_CMP_LE(left: N_EXPR, right: N_EXPR): N_BINOP("<=", left, right, listOf(O_CMP_LE))
-class N_CMP_IN(left: N_EXPR, right: N_EXPR): N_BINOP("in", left, right, listOf(O_CMP_IN))

--- a/src/main/kotlin/value/VList.kt
+++ b/src/main/kotlin/value/VList.kt
@@ -12,6 +12,8 @@ data class VList(var v: MutableList<Value>): Value() {
 
     override fun iterableSize() = v.size
 
+    override fun cmpContains(a2: Value) = v.contains(a2)
+
     override fun getProp(c: Context, name: String): Value? {
         when (name) {
             "length" -> return propSize()

--- a/src/main/kotlin/value/VList.kt
+++ b/src/main/kotlin/value/VList.kt
@@ -12,7 +12,7 @@ data class VList(var v: MutableList<Value>): Value() {
 
     override fun iterableSize() = v.size
 
-    override fun cmpContains(a2: Value) = v.contains(a2)
+    override fun contains(a2: Value) = v.contains(a2)
 
     override fun getProp(c: Context, name: String): Value? {
         when (name) {

--- a/src/main/kotlin/value/VMap.kt
+++ b/src/main/kotlin/value/VMap.kt
@@ -12,6 +12,8 @@ data class VMap(val v: MutableMap<String, Value>): Value() {
     override fun toString() = "[${v.entries.joinToString()}]"
     override fun asString() = v.entries.joinToString(", ")
 
+    override fun cmpContains(a2: Value) = realKeys.values.contains(a2)
+
     override fun getProp(c: Context, name: String): Value? {
         when (name) {
             "length" -> return propLength()

--- a/src/main/kotlin/value/VMap.kt
+++ b/src/main/kotlin/value/VMap.kt
@@ -12,7 +12,7 @@ data class VMap(val v: MutableMap<String, Value>): Value() {
     override fun toString() = "[${v.entries.joinToString()}]"
     override fun asString() = v.entries.joinToString(", ")
 
-    override fun cmpContains(a2: Value) = realKeys.values.contains(a2)
+    override fun contains(a2: Value) = realKeys.values.contains(a2)
 
     override fun getProp(c: Context, name: String): Value? {
         when (name) {

--- a/src/main/kotlin/value/VString.kt
+++ b/src/main/kotlin/value/VString.kt
@@ -13,6 +13,8 @@ data class VString(var v: String): Value() {
 
     override fun iterableSize() = v.length
 
+    override fun cmpContains(a2: Value) = v.contains(a2.asString())
+
     override fun cmpEq(a2: Value) = (a2 is VString) && (v == a2.v)
     override fun cmpGt(a2: Value) = (a2 is VString) && (v > a2.v)
     override fun cmpGe(a2: Value) = (a2 is VString) && (v >= a2.v)

--- a/src/main/kotlin/value/VString.kt
+++ b/src/main/kotlin/value/VString.kt
@@ -13,7 +13,7 @@ data class VString(var v: String): Value() {
 
     override fun iterableSize() = v.length
 
-    override fun cmpContains(a2: Value) = v.contains(a2.asString())
+    override fun contains(a2: Value) = v.contains(a2.asString())
 
     override fun cmpEq(a2: Value) = (a2 is VString) && (v == a2.v)
     override fun cmpGt(a2: Value) = (a2 is VString) && (v > a2.v)

--- a/src/main/kotlin/value/Value.kt
+++ b/src/main/kotlin/value/Value.kt
@@ -36,6 +36,10 @@ sealed class Value {
     fun cmpLt(a2: Value): Boolean = !cmpGe(a2)
     fun cmpLe(a2: Value): Boolean = !cmpGt(a2)
 
+    // Boolean 'this in a2'.  Null raises E_TYPE.
+    open fun cmpIn(a2: Value): Boolean? = a2.cmpContains(this)
+    open fun cmpContains(a2: Value): Boolean? = null
+
     // Math between this type and any other value.  Null raises E_TYPE.
     open fun negate(): Value? = null
     open fun plus(a2: Value): Value? = null

--- a/src/main/kotlin/value/Value.kt
+++ b/src/main/kotlin/value/Value.kt
@@ -37,8 +37,8 @@ sealed class Value {
     fun cmpLe(a2: Value): Boolean = !cmpGt(a2)
 
     // Boolean 'this in a2'.  Null raises E_TYPE.
-    open fun cmpIn(a2: Value): Boolean? = a2.cmpContains(this)
-    open fun cmpContains(a2: Value): Boolean? = null
+    open fun isIn(a2: Value): Boolean? = a2.contains(this)
+    open fun contains(a2: Value): Boolean? = null
 
     // Math between this type and any other value.  Null raises E_TYPE.
     open fun negate(): Value? = null

--- a/src/main/kotlin/vm/Opcode.kt
+++ b/src/main/kotlin/vm/Opcode.kt
@@ -80,6 +80,7 @@ enum class Opcode(val argCount: Int = 0) {
     O_CMP_GE,
     O_CMP_LT,
     O_CMP_LE,
+    O_CMP_IN,
 
     // Push the math result of pop0 and pop1.
     O_ADD,

--- a/src/main/kotlin/vm/Opcode.kt
+++ b/src/main/kotlin/vm/Opcode.kt
@@ -75,12 +75,12 @@ enum class Opcode(val argCount: Int = 0) {
     // Push the boolean result of pop0 and pop1.
     O_AND,
     O_OR,
+    O_IN,
     O_CMP_EQ,
     O_CMP_GT,
     O_CMP_GE,
     O_CMP_LT,
     O_CMP_LE,
-    O_CMP_IN,
 
     // Push the math result of pop0 and pop1.
     O_ADD,

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -214,6 +214,11 @@ class VM(val code: List<VMWord> = listOf()) {
                     if (a1 is VBool && a2 is VBool) push(VBool(a1.v || a2.v))
                     else fail(E_TYPE, "cannot OR ${a1.type} and ${a2.type}")
                 }
+                O_IN -> {
+                    val (a2, a1) = popTwo()
+                    a1.isIn(a2)?.also { push(VBool(it)) }
+                        ?: fail(E_TYPE, "cannot check ${a1.type} in ${a2.type}")
+                }
                 O_CMP_EQ, O_CMP_GT, O_CMP_GE, O_CMP_LT, O_CMP_LE -> {
                     val (a2, a1) = popTwo()
                     when (word.opcode) {
@@ -224,11 +229,6 @@ class VM(val code: List<VMWord> = listOf()) {
                         O_CMP_LE -> push(VBool(a1.cmpLe(a2)))
                         else -> { }
                     }
-                }
-                O_CMP_IN -> {
-                    val (a2, a1) = popTwo()
-                    a1.cmpIn(a2)?.also { push(VBool(it)) }
-                        ?: fail(E_TYPE, "cannot check ${a1.type} in ${a2.type}")
                 }
 
                 // Math ops

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -225,6 +225,11 @@ class VM(val code: List<VMWord> = listOf()) {
                         else -> { }
                     }
                 }
+                O_CMP_IN -> {
+                    val (a2, a1) = popTwo()
+                    a1.cmpIn(a2)?.also { push(VBool(it)) }
+                        ?: fail(E_TYPE, "cannot check ${a1.type} in ${a2.type}")
+                }
 
                 // Math ops
 


### PR DESCRIPTION
Adds a simple 'expr in expr' operator which returns a bool representing whether expr1 is contained in expr2.  Works for string/map/list targets with any expr1 type.

I put this up partly to demonstrate end-to-end what's needed to create a new language construct, from parsing to compiling to executing.

```
foolist = [3,5,7,12,26]
output = "I see ${9 in foolist}"

foostring = "Hello world."
footest = "lo w" in foostring
output = "$output and $footest"
return output

RESULT:
"I see false and true"
```