### PR TITLE
Static verb calls

### DIFF
--- a/src/main/kotlin/Yegg.kt
+++ b/src/main/kotlin/Yegg.kt
@@ -7,8 +7,6 @@ import com.dlfsystems.value.VObj
 
 object Yegg {
 
-    val vNullObj = VObj(null)
-
     // TODO: users, auth, *waves hands*
     class Connection() {
 
@@ -68,8 +66,8 @@ object Yegg {
         }
     }
 
-
-    var logLevel: Log.Level = Log.Level.DEBUG
+    val vNullObj = VObj(null)
+    var logLevel = Log.Level.DEBUG
     lateinit var world: World
 
     fun start() {

--- a/src/main/kotlin/Yegg.kt
+++ b/src/main/kotlin/Yegg.kt
@@ -1,5 +1,6 @@
 package com.dlfsystems
 
+import com.dlfsystems.app.Log
 import com.dlfsystems.world.World
 import com.dlfsystems.compiler.Compiler
 
@@ -64,6 +65,8 @@ object Yegg {
         }
     }
 
+
+    var logLevel: Log.Level = Log.Level.DEBUG
     lateinit var world: World
 
     fun start() {

--- a/src/main/kotlin/Yegg.kt
+++ b/src/main/kotlin/Yegg.kt
@@ -4,6 +4,7 @@ import com.dlfsystems.app.Log
 import com.dlfsystems.world.World
 import com.dlfsystems.compiler.Compiler
 import com.dlfsystems.value.VObj
+import com.dlfsystems.value.VTrait
 
 object Yegg {
 
@@ -67,6 +68,8 @@ object Yegg {
     }
 
     val vNullObj = VObj(null)
+    val vNullTrait = VTrait(null)
+
     var logLevel = Log.Level.DEBUG
     lateinit var world: World
 

--- a/src/main/kotlin/Yegg.kt
+++ b/src/main/kotlin/Yegg.kt
@@ -3,8 +3,11 @@ package com.dlfsystems
 import com.dlfsystems.app.Log
 import com.dlfsystems.world.World
 import com.dlfsystems.compiler.Compiler
+import com.dlfsystems.value.VObj
 
 object Yegg {
+
+    val vNullObj = VObj(null)
 
     // TODO: users, auth, *waves hands*
     class Connection() {

--- a/src/main/kotlin/Yegg.kt
+++ b/src/main/kotlin/Yegg.kt
@@ -37,6 +37,7 @@ object Yegg {
             val words = text.split(" ")
             return when (words[0].substring(1, words[0].length)) {
                 "program" -> parseProgram(words)
+                "list" -> parseList(words)
                 "quit" -> parseQuit(words)
                 else -> "I don't understand that."
             }
@@ -48,6 +49,13 @@ object Yegg {
             if (terms.size != 2) return "@program what?"
             programming = Pair(terms[0], terms[1])
             return "Enter verbcode.  Terminate with '.' on a line by itself."
+        }
+
+        fun parseList(words: List<String>): String {
+            if (words.size < 2) return "@list what?"
+            val terms = words[1].split(".")
+            if (terms.size != 2) return "@list what?"
+            return world.listVerb(terms[0], terms[1])
         }
 
         fun parseQuit(words: List<String>): String {

--- a/src/main/kotlin/app/Log.kt
+++ b/src/main/kotlin/app/Log.kt
@@ -1,0 +1,18 @@
+package com.dlfsystems.app
+
+// TODO: write actual logfile, server log level, etc
+object Log {
+
+    fun i(m: String) {
+        println(m)
+    }
+
+    fun w(m: String) {
+        println("WARN: $m")
+    }
+
+    fun e(m: String) {
+        println("ERR: $m")
+    }
+
+}

--- a/src/main/kotlin/app/Log.kt
+++ b/src/main/kotlin/app/Log.kt
@@ -4,12 +4,12 @@ import com.dlfsystems.Yegg
 
 object Log {
 
-    enum class Level { DEBUG, INFO, WARN, ERR }
+    enum class Level { DEBUG, INFO, WARN, ERROR }
 
     fun d(m: String) { log(Level.DEBUG, m) }
     fun i(m: String) { log(Level.INFO, m) }
     fun w(m: String) { log(Level.WARN, m) }
-    fun e(m: String) { log(Level.ERR, m) }
+    fun e(m: String) { log(Level.ERROR, m) }
 
     // TODO: write actual logfile
     private fun log(level: Level, m: String) {

--- a/src/main/kotlin/app/Log.kt
+++ b/src/main/kotlin/app/Log.kt
@@ -1,18 +1,21 @@
 package com.dlfsystems.app
 
-// TODO: write actual logfile, server log level, etc
+import com.dlfsystems.Yegg
+
 object Log {
 
-    fun i(m: String) {
-        println(m)
-    }
+    enum class Level { DEBUG, INFO, WARN, ERR }
 
-    fun w(m: String) {
-        println("WARN: $m")
-    }
+    fun d(m: String) { log(Level.DEBUG, m) }
+    fun i(m: String) { log(Level.INFO, m) }
+    fun w(m: String) { log(Level.WARN, m) }
+    fun e(m: String) { log(Level.ERR, m) }
 
-    fun e(m: String) {
-        println("ERR: $m")
+    // TODO: write actual logfile
+    private fun log(level: Level, m: String) {
+        if (level >= Yegg.logLevel) {
+            println("$level: $m")
+        }
     }
 
 }

--- a/src/main/kotlin/compiler/Coder.kt
+++ b/src/main/kotlin/compiler/Coder.kt
@@ -137,7 +137,7 @@ class Coder(val ast: Node) {
         private fun consume(vararg opcodes: Opcode?, check: ((List<VMWord>)->Boolean)? = null): List<VMWord>? {
             if (opcodes.size > (source.size - pc)) return null
             var hit = true
-            var nulls = mutableListOf<VMWord>()
+            val nulls = mutableListOf<VMWord>()
             opcodes.forEachIndexed { i, t ->
                 if (t == null) nulls.add(source[pc + i])
                 else if ((pc + i) in jumpMap.keys) hit = false  // Miss if we overlap a jump dest

--- a/src/main/kotlin/compiler/Coder.kt
+++ b/src/main/kotlin/compiler/Coder.kt
@@ -80,26 +80,6 @@ class Coder(val ast: Node) {
         mem.add(VMWord(from.lineNum, from.charNum, address = dest))
     }
 
-    fun dumpText(): String {
-        var s = ""
-        var pc = 0
-        while (pc < mem.size) {
-            val cell = mem[pc]
-            s += "<$pc> "
-            s += cell.toString()
-            cell.opcode?.also { opcode ->
-                repeat (opcode.argCount) {
-                    pc++
-                    val arg = mem[pc]
-                    s += " $arg"
-                }
-            }
-            s += "\n"
-            pc++
-        }
-        return s
-    }
-
 
     object Optimizer {
         var source = ArrayList<VMWord>()

--- a/src/main/kotlin/compiler/CompileException.kt
+++ b/src/main/kotlin/compiler/CompileException.kt
@@ -6,13 +6,13 @@ import com.dlfsystems.vm.VMWord
 
 class CompileException(m: String, lineNum: Int, charNum: Int): Exception("$m at line $lineNum c$charNum") {
     var code: List<VMWord>? = null
-    var variableIDs: Map<String, Int>? = null
+    var symbols: Map<String, Int>? = null
     var tokens: List<Token>? = null
     var ast: Node? = null
 
     fun withInfo(c: List<VMWord>?, vids: Map<String, Int>?, t: List<Token>?, a: Node?): CompileException {
         code = c
-        variableIDs = vids
+        symbols = vids
         tokens = t
         ast = a
         return this

--- a/src/main/kotlin/compiler/CompileException.kt
+++ b/src/main/kotlin/compiler/CompileException.kt
@@ -9,4 +9,12 @@ class CompileException(m: String, lineNum: Int, charNum: Int): Exception("$m at 
     var variableIDs: Map<String, Int>? = null
     var tokens: List<Token>? = null
     var ast: Node? = null
+
+    fun withInfo(c: List<VMWord>?, vids: Map<String, Int>?, t: List<Token>?, a: Node?): CompileException {
+        code = c
+        variableIDs = vids
+        tokens = t
+        ast = a
+        return this
+    }
 }

--- a/src/main/kotlin/compiler/CompileException.kt
+++ b/src/main/kotlin/compiler/CompileException.kt
@@ -1,4 +1,12 @@
 package com.dlfsystems.compiler
 
+import com.dlfsystems.compiler.ast.Node
+import com.dlfsystems.vm.VMWord
 
-class CompileException(m: String, lineNum: Int, charNum: Int): Exception("$m at line $lineNum c$charNum")
+
+class CompileException(m: String, lineNum: Int, charNum: Int): Exception("$m at line $lineNum c$charNum") {
+    var code: List<VMWord>? = null
+    var variableIDs: Map<String, Int>? = null
+    var tokens: List<Token>? = null
+    var ast: Node? = null
+}

--- a/src/main/kotlin/compiler/Compiler.kt
+++ b/src/main/kotlin/compiler/Compiler.kt
@@ -46,11 +46,11 @@ object Compiler {
     }
 
     fun eval(code: String, verbose: Boolean = false): String {
-        Log.i("eval: $code")
+        Log.d("eval: $code")
         var cOut: Compiler.Result? = null
         try {
             cOut = compile(code)
-            Log.i("opcodes: \n${cOut.code.dumpText()}")
+            Log.d("  opcodes: \n${cOut.code.dumpText()}")
             val vmOut = VM(cOut.code).execute(Context(Yegg.world)).asString()
             return if (verbose) {
                 "TOKENS:\n${cOut.tokens}\n\nNODES:\n${cOut.ast}\n\nCODE:\n${cOut.code.dumpText()}\nRESULT:\n$vmOut\n"

--- a/src/main/kotlin/compiler/Compiler.kt
+++ b/src/main/kotlin/compiler/Compiler.kt
@@ -7,56 +7,60 @@ import com.dlfsystems.vm.*
 
 object Compiler {
 
-    class Result {
-        var code: List<VMWord>? = null
-        var variableIDs: Map<String, Int>? = null
-        var tokens: List<Token>? = null
-        var ast: Node? = null
-        var opcodeDump: String? = null
-        var e: Exception? = null
-    }
+    class Result(
+        var code: List<VMWord>,
+        var variableIDs: Map<String, Int>,
+        var tokens: List<Token>,
+        var ast: Node,
+    )
 
-    fun compile(code: String): Result {
-        val result = Result()
+    fun compile(source: String): Result {
+        var tokens: List<Token>? = null
+        var code: List<VMWord>? = null
+        var ast: Node? = null
+        var variableIDs: Map<String, Int>? = null
         try {
             // Stage 1: Lex source into tokens.
-            result.tokens = Lexer(code).lex()
+            tokens = Lexer(source).lex()
             // Stage 2: Parse tokens into AST nodes.
-            val parser = Parser(result.tokens!!)
+            val parser = Parser(tokens)
             // Stage 3: Find variables and optimize tree nodes.
             val shaker = Shaker(parser.parse())
-            result.ast = shaker.shake()
-            result.variableIDs = shaker.variableIDs
+            ast = shaker.shake()
+            variableIDs = shaker.variableIDs
             // Stage 4: Generate VM opcodes.
-            val coder = Coder(result.ast!!).apply {
+            val coder = Coder(ast).apply {
                 generate()
                 postOptimize()
             }
-            result.opcodeDump = coder.mem.dumpText()
-            result.code = coder.mem
+            code = coder.mem
+            return Result(code, variableIDs, tokens, ast)
         } catch (e: Exception) {
-            result.e = e
+            throw (if (e is CompileException) e else CompileException("COMPILER CRASH: " + e.stackTraceToString(), 0, 0)).apply {
+                code = code
+                variableIDs = variableIDs
+                tokens = tokens
+                ast = ast
+            }
         }
-        return result
     }
-
-
 
     fun eval(code: String, verbose: Boolean = false): String {
         Log.i("eval: $code")
-        val compilerResult = compile(code)
-        var vmResult = ""
-        compilerResult.code?.also { outcode ->
-            Log.i("opcodes: \n${outcode.dumpText()}")
-            try {
-                VM(outcode).execute(Context(Yegg.world)).also { vmResult = it.asString() }
-            } catch (e: Exception) {
-                vmResult = if (e is VMException) e.toString() else e.toString() + "\n" + e.stackTrace.joinToString("\n  ")
-            }
+        var cOut: Compiler.Result? = null
+        try {
+            cOut = compile(code)
+            Log.i("opcodes: \n${cOut.code.dumpText()}")
+            val vmOut = VM(cOut.code).execute(Context(Yegg.world)).asString()
+            return if (verbose) {
+                "TOKENS:\n${cOut.tokens}\n\nNODES:\n${cOut.ast}\n\nCODE:\n${cOut.code.dumpText()}\nRESULT:\n$vmOut\n"
+            } else "$vmOut\n"
+        } catch (e: Exception) {
+            return if (verbose) {
+                if (e is CompileException) "TOKENS:\n${e.tokens}\n\nNODES:\n${e.ast}\n\nCODE:\n${e.code?.dumpText()}\n"
+                else "TOKENS:\n${cOut?.tokens}\n\nNODES:\n${cOut?.ast}\n\nCODE:\n${cOut?.code?.dumpText()}\n"
+            } else e.toString()
         }
-        return if (verbose)
-            "TOKENS:\n${compilerResult.tokens}\n\nNODES:\n${compilerResult.ast}\n\nCODE:\n${compilerResult.opcodeDump}\n\nRESULT:\n$vmResult\n"
-        else "$vmResult\n"
     }
 
 }

--- a/src/main/kotlin/compiler/Compiler.kt
+++ b/src/main/kotlin/compiler/Compiler.kt
@@ -44,19 +44,19 @@ object Compiler {
 
     fun eval(code: String, verbose: Boolean = false): String {
         Log.d("eval: $code")
-        var cOut: Compiler.Result? = null
+        var cOut: Result? = null
+        val c = Context(Yegg.world).apply {
+            push(VObj(null),  VTrait(null), "(eval)", listOf(VString(code)))
+        }
         try {
             cOut = compile(code)
             Log.d("  opcodes: \n${cOut.code.dumpText()}")
-            val c = Context(Yegg.world).apply {
-                push(VObj(null),  VTrait(null), "(eval)", listOf(VString(code)))
-            }
-            val vmOut = VM(cOut.code).execute(c).asString()
+            val vmOut = VM(cOut.code, cOut.variableIDs).execute(c).asString()
             return if (verbose) dumpText(cOut.tokens, cOut.ast, cOut.code, vmOut) else vmOut
         } catch (e: CompileException) {
             return if (verbose) dumpText(e.tokens, e.ast, e.code, "") else e.toString()
         } catch (e: Exception) {
-            return dumpText(cOut?.tokens, cOut?.ast, cOut?.code, "")
+            return if (verbose) dumpText(cOut?.tokens, cOut?.ast, cOut?.code, "") else "$e\n${c.stackDump()}"
         }
     }
 

--- a/src/main/kotlin/compiler/Compiler.kt
+++ b/src/main/kotlin/compiler/Compiler.kt
@@ -3,6 +3,9 @@ package com.dlfsystems.compiler
 import com.dlfsystems.Yegg
 import com.dlfsystems.app.Log
 import com.dlfsystems.compiler.ast.Node
+import com.dlfsystems.value.VObj
+import com.dlfsystems.value.VString
+import com.dlfsystems.value.VTrait
 import com.dlfsystems.vm.*
 
 object Compiler {
@@ -45,7 +48,10 @@ object Compiler {
         try {
             cOut = compile(code)
             Log.d("  opcodes: \n${cOut.code.dumpText()}")
-            val vmOut = VM(cOut.code).execute(Context(Yegg.world)).asString()
+            val c = Context(Yegg.world).apply {
+                push(VObj(null),  VTrait(null), "(eval)", listOf(VString(code)))
+            }
+            val vmOut = VM(cOut.code).execute(c).asString()
             return if (verbose) dumpText(cOut.tokens, cOut.ast, cOut.code, vmOut) else vmOut
         } catch (e: CompileException) {
             return if (verbose) dumpText(e.tokens, e.ast, e.code, "") else e.toString()

--- a/src/main/kotlin/compiler/Compiler.kt
+++ b/src/main/kotlin/compiler/Compiler.kt
@@ -12,7 +12,7 @@ object Compiler {
 
     class Result(
         val code: List<VMWord>,
-        val variableIDs: Map<String, Int>,
+        val symbols: Map<String, Int>,
         val tokens: List<Token>,
         val ast: Node,
     )
@@ -21,7 +21,7 @@ object Compiler {
         var tokens: List<Token>? = null
         var code: List<VMWord>? = null
         var ast: Node? = null
-        var variableIDs: Map<String, Int>? = null
+        var symbols: Map<String, Int>? = null
         try {
             // Stage 1: Lex source into tokens.
             tokens = Lexer(source).lex()
@@ -30,15 +30,15 @@ object Compiler {
             // Stage 3: Find variables.
             val shaker = Shaker(parser.parse())
             ast = shaker.shake()
-            variableIDs = shaker.variableIDs
+            symbols = shaker.symbols
             // Stage 4: Generate VM opcodes.
             code = Coder(ast).generate()
-            return Result(code, variableIDs, tokens, ast)
+            return Result(code, symbols, tokens, ast)
         } catch (e: CompileException) {
-            throw e.withInfo(code, variableIDs, tokens, ast)
+            throw e.withInfo(code, symbols, tokens, ast)
         } catch (e: Exception) {
             throw CompileException("GURU: " + e.stackTraceToString(), 0, 0)
-                .withInfo(code, variableIDs, tokens, ast)
+                .withInfo(code, symbols, tokens, ast)
         }
     }
 
@@ -51,7 +51,7 @@ object Compiler {
         try {
             cOut = compile(code)
             Log.d("  opcodes: \n${cOut.code.dumpText()}")
-            val vmOut = VM(cOut.code, cOut.variableIDs).execute(c).asString()
+            val vmOut = VM(cOut.code, cOut.symbols).execute(c).asString()
             return if (verbose) dumpText(cOut.tokens, cOut.ast, cOut.code, vmOut) else vmOut
         } catch (e: CompileException) {
             return if (verbose) dumpText(e.tokens, e.ast, e.code, "") else e.toString()

--- a/src/main/kotlin/compiler/Compiler.kt
+++ b/src/main/kotlin/compiler/Compiler.kt
@@ -46,7 +46,7 @@ object Compiler {
         Log.d("eval: $code")
         var cOut: Result? = null
         val c = Context(Yegg.world).apply {
-            push(VObj(null),  VTrait(null), "(eval)", listOf(VString(code)))
+            push(Yegg.vNullObj, Yegg.vNullTrait, "(eval)", listOf(VString(code)))
         }
         try {
             cOut = compile(code)

--- a/src/main/kotlin/compiler/Compiler.kt
+++ b/src/main/kotlin/compiler/Compiler.kt
@@ -3,14 +3,13 @@ package com.dlfsystems.compiler
 import com.dlfsystems.Yegg
 import com.dlfsystems.app.Log
 import com.dlfsystems.compiler.ast.Node
-import com.dlfsystems.value.VObj
 import com.dlfsystems.value.VString
-import com.dlfsystems.value.VTrait
 import com.dlfsystems.vm.*
 
 object Compiler {
 
     class Result(
+        val source: String,
         val code: List<VMWord>,
         val symbols: Map<String, Int>,
         val tokens: List<Token>,
@@ -33,7 +32,7 @@ object Compiler {
             symbols = shaker.symbols
             // Stage 4: Generate VM opcodes.
             code = Coder(ast).generate()
-            return Result(code, symbols, tokens, ast)
+            return Result(source, code, symbols, tokens, ast)
         } catch (e: CompileException) {
             throw e.withInfo(code, symbols, tokens, ast)
         } catch (e: Exception) {

--- a/src/main/kotlin/compiler/Shaker.kt
+++ b/src/main/kotlin/compiler/Shaker.kt
@@ -7,7 +7,7 @@ import com.dlfsystems.compiler.ast.Node
 
 class Shaker(val root: Node) {
 
-    val variableIDs = mutableMapOf<String, Int>()
+    val symbols = mutableMapOf<String, Int>()
 
     fun shake(): Node {
 
@@ -17,8 +17,8 @@ class Shaker(val root: Node) {
         // Collect all unique variable names.
         root.traverse {
             if (it is N_IDENTIFIER && it.isVariable()) {
-                if (!variableIDs.containsKey(it.name)) {
-                    variableIDs[it.name] = variableIDs.size
+                if (!symbols.containsKey(it.name)) {
+                    symbols[it.name] = symbols.size
                 }
             }
         }
@@ -26,7 +26,7 @@ class Shaker(val root: Node) {
         // Set the variable ID for all variables.
         root.traverse {
             if (it is N_IDENTIFIER && it.isVariable()) {
-                it.variableID = variableIDs[it.name]
+                it.variableID = symbols[it.name]
             }
         }
 

--- a/src/main/kotlin/compiler/Shaker.kt
+++ b/src/main/kotlin/compiler/Shaker.kt
@@ -8,8 +8,7 @@ import com.dlfsystems.compiler.ast.Node
 
 class Shaker(val root: Node) {
 
-    val varIDs = mutableListOf<String>()
-    val varNameToID = mutableMapOf<String, Int>()
+    val variableIDs = mutableMapOf<String, Int>()
 
     fun shake(): Node {
 
@@ -19,9 +18,8 @@ class Shaker(val root: Node) {
         // Collect all unique variable names.
         root.traverse {
             if (it is N_IDENTIFIER && it.isVariable()) {
-                if (!varIDs.contains(it.name)) {
-                    varNameToID[it.name] = varIDs.size
-                    varIDs.add(it.name)
+                if (!variableIDs.containsKey(it.name)) {
+                    variableIDs[it.name] = variableIDs.size
                 }
             }
         }
@@ -29,7 +27,7 @@ class Shaker(val root: Node) {
         // Set the variable ID for all variables.
         root.traverse {
             if (it is N_IDENTIFIER && it.isVariable()) {
-                it.variableID = varNameToID[it.name]
+                it.variableID = variableIDs[it.name]
             }
         }
 

--- a/src/main/kotlin/compiler/Shaker.kt
+++ b/src/main/kotlin/compiler/Shaker.kt
@@ -3,8 +3,7 @@ package com.dlfsystems.compiler
 import com.dlfsystems.compiler.ast.N_IDENTIFIER
 import com.dlfsystems.compiler.ast.Node
 
-// Validate the tree for semantic consistency.
-// Label nodes along the way (variable IDs, etc) to assist execution.
+// Assign variable IDs to identifiers.
 
 class Shaker(val root: Node) {
 

--- a/src/main/kotlin/value/VList.kt
+++ b/src/main/kotlin/value/VList.kt
@@ -119,4 +119,9 @@ data class VList(var v: MutableList<Value>): Value() {
         requireArgCount(args, 1, 1)
         return if (v.contains(args[0])) VInt(v.indexOf(args[0])) else VInt(-1)
     }
+
+    companion object {
+        // TODO: figure out consistent mutability semantics
+        fun make(v: List<Value>) = VList(v.toMutableList())
+    }
 }

--- a/src/main/kotlin/vm/Context.kt
+++ b/src/main/kotlin/vm/Context.kt
@@ -10,15 +10,23 @@ import java.util.UUID
 class Context(
     val world: World = World()
 ) {
+    class Call(
+        val vThis: Value,
+        val verb: String,
+        val args: List<Value>,
+    )
 
     var vThis: VObj = VObj(null)
     var vUser: VObj = VObj(null)
 
     var ticksLeft: Int = (world.getSysValue(this, "tickLimit") as VInt).v
-    val callStack = VMCallstack()
+    val callStack = ArrayDeque<Call>()
 
+    // Push or pop the callstack.
+    fun push(vThis: Value, verb: String, args: List<Value>) = callStack.addFirst(Call(vThis, verb, args))
+    fun pop(): Call = callStack.removeFirst()
 
-    fun getTrait(name: String) = world?.getTrait(name)
-    fun getTrait(id: UUID) = world?.getTrait(id)
+    fun getTrait(name: String) = world.getTrait(name)
+    fun getTrait(id: UUID) = world.getTrait(id)
 
 }

--- a/src/main/kotlin/vm/Context.kt
+++ b/src/main/kotlin/vm/Context.kt
@@ -1,5 +1,6 @@
 package com.dlfsystems.vm
 
+import com.dlfsystems.Yegg
 import com.dlfsystems.world.World
 import com.dlfsystems.value.*
 import kotlin.uuid.Uuid
@@ -19,8 +20,8 @@ class Context(
         override fun toString() = "$vThis $vTrait.$verb(${args.joinToString(",")})"
     }
 
-    var vThis: VObj = VObj(null)
-    var vUser: VObj = VObj(null)
+    var vThis: VObj = Yegg.vNullObj
+    var vUser: VObj = Yegg.vNullObj
 
     var ticksLeft: Int = (world.getSysValue(this, "tickLimit") as VInt).v
     val callLimit: Int = (world.getSysValue(this, "callLimit") as VInt).v

--- a/src/main/kotlin/vm/Context.kt
+++ b/src/main/kotlin/vm/Context.kt
@@ -12,7 +12,7 @@ class Context(
 ) {
 
     var vThis: VObj = VObj(null)
-    var vPlayer: VObj = VObj(null)
+    var vUser: VObj = VObj(null)
 
     var ticksLeft: Int = (world.getSysValue(this, "tickLimit") as VInt).v
     val callStack = VMCallstack()

--- a/src/main/kotlin/vm/Context.kt
+++ b/src/main/kotlin/vm/Context.kt
@@ -11,7 +11,8 @@ class Context(
     val world: World = World()
 ) {
     class Call(
-        val vThis: Value,
+        val vThis: VObj,
+        val vTrait: VTrait,
         val verb: String,
         val args: List<Value>,
     )
@@ -23,7 +24,7 @@ class Context(
     val callStack = ArrayDeque<Call>()
 
     // Push or pop the callstack.
-    fun push(vThis: Value, verb: String, args: List<Value>) = callStack.addFirst(Call(vThis, verb, args))
+    fun push(vThis: VObj, vTrait: VTrait, verb: String, args: List<Value>) = callStack.addFirst(Call(vThis, vTrait, verb, args))
     fun pop(): Call = callStack.removeFirst()
 
     fun getTrait(name: String) = world.getTrait(name)

--- a/src/main/kotlin/vm/Context.kt
+++ b/src/main/kotlin/vm/Context.kt
@@ -21,6 +21,7 @@ class Context(
     var vUser: VObj = VObj(null)
 
     var ticksLeft: Int = (world.getSysValue(this, "tickLimit") as VInt).v
+    val callLimit: Int = (world.getSysValue(this, "callLimit") as VInt).v
     val callStack = ArrayDeque<Call>()
 
     // Push or pop the callstack.

--- a/src/main/kotlin/vm/Context.kt
+++ b/src/main/kotlin/vm/Context.kt
@@ -15,7 +15,9 @@ class Context(
         val vTrait: VTrait,
         val verb: String,
         val args: List<Value>,
-    )
+    ) {
+        override fun toString() = "$vThis $vTrait.$verb(${args.joinToString(",")})"
+    }
 
     var vThis: VObj = VObj(null)
     var vUser: VObj = VObj(null)
@@ -25,10 +27,13 @@ class Context(
     val callStack = ArrayDeque<Call>()
 
     // Push or pop the callstack.
-    fun push(vThis: VObj, vTrait: VTrait, verb: String, args: List<Value>) = callStack.addFirst(Call(vThis, vTrait, verb, args))
-    fun pop(): Call = callStack.removeFirst()
+    fun push(vThis: VObj, vTrait: VTrait, verb: String, args: List<Value>) =
+        callStack.addFirst(Call(vThis, vTrait, verb, args))
+    fun pop(): Call =
+        callStack.removeFirst()
 
     fun getTrait(name: String) = world.getTrait(name)
     fun getTrait(id: UUID) = world.getTrait(id)
 
+    fun stackDump() = callStack.joinToString(separator = "\n  ", postfix = "\n")
 }

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -9,7 +9,7 @@ import com.dlfsystems.vm.VMException.Type.*
 
 class VM(
     val code: List<VMWord> = listOf(),
-    val variableIDs: Map<String, Int> = mapOf()
+    val symbols: Map<String, Int> = mapOf()
 ) {
 
     // Program Counter: index of the opcode we're about to execute (or argument we're about to fetch).
@@ -59,7 +59,7 @@ class VM(
 
     // Initialize a variable to a value before execution.
     private fun initVar(name: String, value: Value) {
-        variableIDs[name]?.also { variables[it] = value }
+        symbols[name]?.also { variables[it] = value }
     }
 
     private fun executeCode(c: Context): Value {

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -305,13 +305,6 @@ data class VMWord(
         get() = (value as VInt).v
 }
 
-// A stack recording the history of a chain of nested func calls, held by a Context.
-class VMCallstack {
-    class Call()
-
-    private val stack = ArrayDeque<Call>()
-}
-
 fun List<VMWord>.dumpText(): String {
     if (isEmpty()) return "<not programmed>\n"
     var s = ""

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -284,7 +284,7 @@ class VM(
 // An atom of VM opcode memory.
 // Can hold an Opcode, a Value, or an int representing a memory address (for jumps).
 // TODO: rework this as a sealed class like Value
-class VMWord(
+data class VMWord(
     val lineNum: Int, val charNum: Int,
     val opcode: Opcode? = null, val value: Value? = null, var address: Int? = null
 ) {

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -147,6 +147,7 @@ class VM(
                     val args = mutableListOf<Value>()
                     repeat(argCount) { args.add(pop()) }
                     if (a2 is VString) {
+                        if (c.callStack.size >= c.callLimit) fail(E_MAXREC, "call limit exceeded")
                         c.ticksLeft = ticksLeft
                         a1.callVerb(c, a2.v, args)?.also { push(it) }
                             ?: fail(E_VERBNF, "verb not found")

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -7,7 +7,10 @@ import com.dlfsystems.vm.VMException.Type.*
 
 // A stack machine for executing a verb.
 
-class VM(val code: List<VMWord> = listOf()) {
+class VM(
+    val code: List<VMWord> = listOf(),
+    val variableIDs: Map<String, Int> = mapOf()
+) {
 
     // Program Counter: index of the opcode we're about to execute (or argument we're about to fetch).
     private var pc: Int = 0
@@ -31,15 +34,18 @@ class VM(val code: List<VMWord> = listOf()) {
     private inline fun popFour() = listOf(stack.removeFirst(), stack.removeFirst(), stack.removeFirst(), stack.removeFirst())
     private inline fun next() = code[pc++]
 
-    // Given a Context, execute each word of the input code starting from pc=0.
+    // Given a Context and args, execute each word of the input code starting from pc=0.
     // Mutate the stack and variables as we go.
     // Return back a Value (VVoid if no explicit return).
-    fun execute(c: Context? = null): Value {
+    fun execute(c: Context, args: List<Value> = listOf()): Value {
         // Intercept success or failure, so we get to clean up either way.
         var returnValue: Value? = null
         var exception: Exception? = null
         try {
-            returnValue = executeCode(c ?: Context())
+            initVar("args", VList.make(args))
+            initVar("this", c.vThis)
+            initVar("user", c.vUser)
+            returnValue = executeCode(c)
         } catch (e: Exception) {
             exception = e as? VMException ?: VMException(E_SYS, e.toString(), lineNum, charNum)
         }
@@ -49,6 +55,11 @@ class VM(val code: List<VMWord> = listOf()) {
         // Then we succeed or fail.
         exception?.also { throw it }
         return returnValue!!
+    }
+
+    // Initialize a variable to a value before execution.
+    private fun initVar(name: String, value: Value) {
+        variableIDs[name]?.also { variables[it] = value }
     }
 
     private fun executeCode(c: Context): Value {
@@ -137,11 +148,9 @@ class VM(val code: List<VMWord> = listOf()) {
                     repeat(argCount) { args.add(pop()) }
                     if (a2 is VString) {
                         c.ticksLeft = ticksLeft
-                        // TODO: put our frame on the callstack (opt: skip this for builtin type verbs?)
                         a1.callVerb(c, a2.v, args)?.also { push(it) }
                             ?: fail(E_VERBNF, "verb not found")
                     } else fail(E_VERBNF, "verb name must be string")
-                    // TODO: pop our frame off the callstack
                     ticksLeft = c.ticksLeft
                 }
 
@@ -301,4 +310,25 @@ class VMCallstack {
     class Call()
 
     private val stack = ArrayDeque<Call>()
+}
+
+fun List<VMWord>.dumpText(): String {
+    if (isEmpty()) return "<not programmed>\n"
+    var s = ""
+    var pc = 0
+    while (pc < size) {
+        val cell = get(pc)
+        s += "<$pc> "
+        s += cell.toString()
+        cell.opcode?.also { opcode ->
+            repeat (opcode.argCount) {
+                pc++
+                val arg = get(pc)
+                s += " $arg"
+            }
+        }
+        s += "\n"
+        pc++
+    }
+    return s
 }

--- a/src/main/kotlin/vm/VMException.kt
+++ b/src/main/kotlin/vm/VMException.kt
@@ -25,8 +25,11 @@ class VMException(val type: Type, val m: String, val lineNum: Int, val charNum: 
         // Division by zero
         E_DIV,
 
-        // System resource limit exceeded (stack, ticks)
+        // System resource limit exceeded
         E_LIMIT,
+
+        // Callstack recursion limit exceeded
+        E_MAXREC,
 
         // Other system failures
         E_SYS,

--- a/src/main/kotlin/world/World.kt
+++ b/src/main/kotlin/world/World.kt
@@ -33,11 +33,13 @@ class World {
 
     fun programVerb(traitName: String, name: String, code: String): String {
         getTrait(traitName)?.also { trait ->
-            val result = Compiler.compile(code)
-            result.code?.also { outcode ->
-                trait.programVerb(name, outcode, result.variableIDs!!)
-                return "programmed \$${traitName}.${name} (${outcode.size} words)"
-            } ?: return "compile error: ${result.e}"
+            try {
+                val result = Compiler.compile(code)
+                trait.programVerb(name, result.code, result.variableIDs)
+                return "programmed \$${traitName}.${name} (${result.code.size} words)"
+            } catch (e: Exception) {
+                return "compile error: $e"
+            }
         }
         return "ERR: unknown trait $traitName"
     }

--- a/src/main/kotlin/world/World.kt
+++ b/src/main/kotlin/world/World.kt
@@ -34,9 +34,9 @@ class World {
     fun programVerb(traitName: String, name: String, code: String): String {
         getTrait(traitName)?.also { trait ->
             try {
-                val result = Compiler.compile(code)
-                trait.programVerb(name, result.code, result.variableIDs)
-                return "programmed \$${traitName}.${name} (${result.code.size} words)"
+                val cOut = Compiler.compile(code)
+                trait.programVerb(name, cOut)
+                return "programmed \$${traitName}.${name} (${cOut.code.size} words)"
             } catch (e: Exception) {
                 return "compile error: $e"
             }

--- a/src/main/kotlin/world/World.kt
+++ b/src/main/kotlin/world/World.kt
@@ -35,9 +35,18 @@ class World {
         getTrait(traitName)?.also { trait ->
             val result = Compiler.compile(code)
             result.code?.also { outcode ->
-                trait.programVerb(name, outcode)
+                trait.programVerb(name, outcode, result.variableIDs!!)
                 return "programmed \$${traitName}.${name} (${outcode.size} words)"
             } ?: return "compile error: ${result.e}"
-        } ?: return "ERR: unknown trait"
+        }
+        return "ERR: unknown trait $traitName"
+    }
+
+    fun listVerb(traitName: String, name: String): String {
+        getTrait(traitName)?.also { trait ->
+            trait.verbs[name]?.also { return it.getListing() }
+                ?: return "ERR: verb not found $name"
+        }
+        return "ERR: unknown trait $traitName"
     }
 }

--- a/src/main/kotlin/world/trait/SysTrait.kt
+++ b/src/main/kotlin/world/trait/SysTrait.kt
@@ -16,18 +16,18 @@ class SysTrait : Trait("sys") {
         "stackLimit" to VInt(100)
     )
 
-    override fun getProp(c: Context, name: String): Value? {
-        when (name) {
+    override fun getProp(c: Context, propName: String): Value? {
+        when (propName) {
             "time" -> return VInt((System.currentTimeMillis() / 1000L).toInt())
         }
-        return super.getProp(c, name)
+        return super.getProp(c, propName)
     }
 
-    override fun callVerb(c: Context, name: String, args: List<Value>): Value? {
-        when (name) {
+    override fun callVerb(c: Context, verbName: String, args: List<Value>): Value? {
+        when (verbName) {
             "addTrait" -> return verbAddTrait(c, args)
         }
-        return null
+        return super.callVerb(c, verbName, args)
     }
 
     private fun verbAddTrait(c: Context, args: List<Value>): Value {

--- a/src/main/kotlin/world/trait/SysTrait.kt
+++ b/src/main/kotlin/world/trait/SysTrait.kt
@@ -13,7 +13,8 @@ class SysTrait : Trait("sys") {
 
     override val props = mutableMapOf<String, Value>(
         "tickLimit" to VInt(100000),
-        "stackLimit" to VInt(100)
+        "stackLimit" to VInt(100),
+        "callLimit" to VInt(50),
     )
 
     override fun getProp(c: Context, propName: String): Value? {

--- a/src/main/kotlin/world/trait/Trait.kt
+++ b/src/main/kotlin/world/trait/Trait.kt
@@ -1,5 +1,6 @@
 package com.dlfsystems.world.trait
 
+import com.dlfsystems.app.Log
 import com.dlfsystems.value.Value
 import com.dlfsystems.vm.Context
 import com.dlfsystems.vm.VMWord
@@ -14,23 +15,24 @@ open class Trait(val name: String) {
     val verbs: MutableMap<String, Verb> = mutableMapOf()
     open val props: MutableMap<String, Value> = mutableMapOf()
 
-    fun programVerb(name: String, code: List<VMWord>) {
+    fun programVerb(name: String, code: List<VMWord>, variableIDs: Map<String, Int>) {
         verbs[name]?.also {
-            it.program(code)
-        } ?: {
-            verbs[name] = Verb(name).apply { program(code) }
+            it.program(code, variableIDs)
+        } ?: run {
+            verbs[name] = Verb(name).apply { program(code, variableIDs) }
         }
     }
 
-    open fun getProp(c: Context, name: String): Value? = props.getOrDefault(name, null)
-    open fun setProp(c: Context, name: String, value: Value): Boolean {
-        props[name] = value
+    open fun getProp(c: Context, propName: String): Value? = props.getOrDefault(propName, null)
+    open fun setProp(c: Context, propName: String, value: Value): Boolean {
+        props[propName] = value
         return true
     }
 
-    open fun callVerb(c: Context, name: String, args: List<Value>): Value? {
-        verbs[name]?.also {
-            // TODO execute verb w args
+    open fun callVerb(c: Context, verbName: String, args: List<Value>): Value? {
+        verbs[verbName]?.also { verb ->
+            Log.i("Call \$$name.$verbName($args)")
+            return verb.call(c, args)
         }
         return null
     }

--- a/src/main/kotlin/world/trait/Trait.kt
+++ b/src/main/kotlin/world/trait/Trait.kt
@@ -1,6 +1,7 @@
 package com.dlfsystems.world.trait
 
 import com.dlfsystems.app.Log
+import com.dlfsystems.value.VTrait
 import com.dlfsystems.value.Value
 import com.dlfsystems.vm.Context
 import com.dlfsystems.vm.VMWord
@@ -11,6 +12,7 @@ import java.util.*
 open class Trait(val name: String) {
 
     val id: UUID = UUID.randomUUID()
+    private val vThis = VTrait(id)
 
     val verbs: MutableMap<String, Verb> = mutableMapOf()
     open val props: MutableMap<String, Value> = mutableMapOf()
@@ -32,7 +34,7 @@ open class Trait(val name: String) {
     open fun callVerb(c: Context, verbName: String, args: List<Value>): Value? {
         verbs[verbName]?.also {
             Log.i("static verb call: \$$name.$verbName($args)")
-            return it.call(c, args)
+            return it.call(c, vThis, args)
         }
         return null
     }

--- a/src/main/kotlin/world/trait/Trait.kt
+++ b/src/main/kotlin/world/trait/Trait.kt
@@ -2,10 +2,10 @@ package com.dlfsystems.world.trait
 
 import com.dlfsystems.Yegg
 import com.dlfsystems.app.Log
+import com.dlfsystems.compiler.Compiler
 import com.dlfsystems.value.VTrait
 import com.dlfsystems.value.Value
 import com.dlfsystems.vm.Context
-import com.dlfsystems.vm.VMWord
 import java.util.*
 
 // A collection of verbs and props, which can apply to an Obj.
@@ -18,11 +18,11 @@ open class Trait(val name: String) {
     val verbs: MutableMap<String, Verb> = mutableMapOf()
     open val props: MutableMap<String, Value> = mutableMapOf()
 
-    fun programVerb(verbName: String, code: List<VMWord>, variableIDs: Map<String, Int>) {
+    fun programVerb(verbName: String, cOut: Compiler.Result) {
         verbs[verbName]?.also {
-            it.program(code, variableIDs)
+            it.program(cOut)
         } ?: run {
-            verbs[verbName] = Verb(verbName).apply { program(code, variableIDs) }
+            verbs[verbName] = Verb(verbName).apply { program(cOut) }
         }
     }
 

--- a/src/main/kotlin/world/trait/Trait.kt
+++ b/src/main/kotlin/world/trait/Trait.kt
@@ -15,11 +15,11 @@ open class Trait(val name: String) {
     val verbs: MutableMap<String, Verb> = mutableMapOf()
     open val props: MutableMap<String, Value> = mutableMapOf()
 
-    fun programVerb(name: String, code: List<VMWord>, variableIDs: Map<String, Int>) {
-        verbs[name]?.also {
+    fun programVerb(verbName: String, code: List<VMWord>, variableIDs: Map<String, Int>) {
+        verbs[verbName]?.also {
             it.program(code, variableIDs)
         } ?: run {
-            verbs[name] = Verb(name).apply { program(code, variableIDs) }
+            verbs[verbName] = Verb(verbName).apply { program(code, variableIDs) }
         }
     }
 
@@ -30,9 +30,9 @@ open class Trait(val name: String) {
     }
 
     open fun callVerb(c: Context, verbName: String, args: List<Value>): Value? {
-        verbs[verbName]?.also { verb ->
-            Log.i("Call \$$name.$verbName($args)")
-            return verb.call(c, args)
+        verbs[verbName]?.also {
+            Log.i("static verb call: \$$name.$verbName($args)")
+            return it.call(c, args)
         }
         return null
     }

--- a/src/main/kotlin/world/trait/Trait.kt
+++ b/src/main/kotlin/world/trait/Trait.kt
@@ -1,5 +1,6 @@
 package com.dlfsystems.world.trait
 
+import com.dlfsystems.Yegg
 import com.dlfsystems.app.Log
 import com.dlfsystems.value.VTrait
 import com.dlfsystems.value.Value
@@ -12,7 +13,7 @@ import java.util.*
 open class Trait(val name: String) {
 
     val id: UUID = UUID.randomUUID()
-    private val vThis = VTrait(id)
+    private val vTrait = VTrait(id)
 
     val verbs: MutableMap<String, Verb> = mutableMapOf()
     open val props: MutableMap<String, Value> = mutableMapOf()
@@ -34,7 +35,7 @@ open class Trait(val name: String) {
     open fun callVerb(c: Context, verbName: String, args: List<Value>): Value? {
         verbs[verbName]?.also {
             Log.i("static verb call: \$$name.$verbName($args)")
-            return it.call(c, vThis, args)
+            return it.call(c, Yegg.vNullObj, vTrait, args)
         }
         return null
     }

--- a/src/main/kotlin/world/trait/Verb.kt
+++ b/src/main/kotlin/world/trait/Verb.kt
@@ -1,6 +1,8 @@
 package com.dlfsystems.world.trait
 
 import com.dlfsystems.app.Log
+import com.dlfsystems.value.VObj
+import com.dlfsystems.value.VTrait
 import com.dlfsystems.value.Value
 import com.dlfsystems.vm.Context
 import com.dlfsystems.vm.VM
@@ -17,8 +19,8 @@ class Verb(
         Log.d("programmed $name with code ${vm.code.dumpText()}")
     }
 
-    fun call(c: Context, vThis: Value, args: List<Value>): Value {
-        c.push(vThis, name, args)
+    fun call(c: Context, vThis: VObj, vTrait: VTrait, args: List<Value>): Value {
+        c.push(vThis, vTrait, name, args)
         val r = vm.execute(c, args)
         c.pop()
         return r

--- a/src/main/kotlin/world/trait/Verb.kt
+++ b/src/main/kotlin/world/trait/Verb.kt
@@ -1,5 +1,6 @@
 package com.dlfsystems.world.trait
 
+import com.dlfsystems.app.Log
 import com.dlfsystems.value.Value
 import com.dlfsystems.vm.Context
 import com.dlfsystems.vm.VM
@@ -12,7 +13,8 @@ class Verb(
     var vm = VM()
 
     fun program(code: List<VMWord>, variableIDs: Map<String, Int>) {
-        vm = VM(code, variableIDs)
+        vm = VM(listOf<VMWord>() + code, mapOf<String, Int>() + variableIDs)
+        Log.d("programmed $name with code ${vm.code.dumpText()}")
     }
 
     fun call(c: Context, args: List<Value>): Value {

--- a/src/main/kotlin/world/trait/Verb.kt
+++ b/src/main/kotlin/world/trait/Verb.kt
@@ -1,12 +1,12 @@
 package com.dlfsystems.world.trait
 
 import com.dlfsystems.app.Log
+import com.dlfsystems.compiler.Compiler
 import com.dlfsystems.value.VObj
 import com.dlfsystems.value.VTrait
 import com.dlfsystems.value.Value
 import com.dlfsystems.vm.Context
 import com.dlfsystems.vm.VM
-import com.dlfsystems.vm.VMWord
 import com.dlfsystems.vm.dumpText
 
 class Verb(
@@ -14,8 +14,8 @@ class Verb(
 ) {
     var vm = VM()
 
-    fun program(code: List<VMWord>, variableIDs: Map<String, Int>) {
-        vm = VM(code, variableIDs)
+    fun program(cOut: Compiler.Result) {
+        vm = VM(cOut.code, cOut.variableIDs)
         Log.d("programmed $name with code ${vm.code.dumpText()}")
     }
 

--- a/src/main/kotlin/world/trait/Verb.kt
+++ b/src/main/kotlin/world/trait/Verb.kt
@@ -13,8 +13,10 @@ class Verb(
     val name: String,
 ) {
     var vm = VM()
+    private var source = ""
 
     fun program(cOut: Compiler.Result) {
+        source = cOut.source
         vm = VM(cOut.code, cOut.symbols)
         Log.d("programmed $name with code ${vm.code.dumpText()}")
     }

--- a/src/main/kotlin/world/trait/Verb.kt
+++ b/src/main/kotlin/world/trait/Verb.kt
@@ -13,12 +13,15 @@ class Verb(
     var vm = VM()
 
     fun program(code: List<VMWord>, variableIDs: Map<String, Int>) {
-        vm = VM(listOf<VMWord>() + code, mapOf<String, Int>() + variableIDs)
+        vm = VM(code, variableIDs)
         Log.d("programmed $name with code ${vm.code.dumpText()}")
     }
 
-    fun call(c: Context, args: List<Value>): Value {
-        return vm.execute(c, args)
+    fun call(c: Context, vThis: Value, args: List<Value>): Value {
+        c.push(vThis, name, args)
+        val r = vm.execute(c, args)
+        c.pop()
+        return r
     }
 
     fun getListing() = vm.code.dumpText()

--- a/src/main/kotlin/world/trait/Verb.kt
+++ b/src/main/kotlin/world/trait/Verb.kt
@@ -15,7 +15,7 @@ class Verb(
     var vm = VM()
 
     fun program(cOut: Compiler.Result) {
-        vm = VM(cOut.code, cOut.variableIDs)
+        vm = VM(cOut.code, cOut.symbols)
         Log.d("programmed $name with code ${vm.code.dumpText()}")
     }
 

--- a/src/main/kotlin/world/trait/Verb.kt
+++ b/src/main/kotlin/world/trait/Verb.kt
@@ -1,18 +1,24 @@
 package com.dlfsystems.world.trait
 
+import com.dlfsystems.value.Value
 import com.dlfsystems.vm.Context
 import com.dlfsystems.vm.VM
 import com.dlfsystems.vm.VMWord
+import com.dlfsystems.vm.dumpText
 
 class Verb(
     val name: String,
 ) {
     var vm = VM()
 
-    fun program(newCode: List<VMWord>) {
-        vm = VM(newCode)
+    fun program(code: List<VMWord>, variableIDs: Map<String, Int>) {
+        vm = VM(code, variableIDs)
     }
 
-    fun execute(context: Context) = vm.execute(context)
+    fun call(c: Context, args: List<Value>): Value {
+        return vm.execute(c, args)
+    }
+
+    fun getListing() = vm.code.dumpText()
 
 }


### PR DESCRIPTION
Unrelated changes:
- Added Log singleton
- Refactored Compiler.Result and Coder
- Renamed some func args, added privates, etc

This PR enables calling static verbs on bare $traits, with arguments.  Obj-trait relationships, hence obj.verb() calls, are still in the future.

Apologies for the big changeset; doing this brought together a lot of things that hadn't really touched before, so a lot of edges had to get filed down and refitted, but I think it's a bit better organized now.

```
> @program room.getSmell
< Enter verbcode.  Terminate with '.' on a line by itself.
> smells = ["cheesy", "oily", "sweet", "like feet"]
> return "It smells ${smells[args[0]]}."
> .
< programmed $room.getSmell (27 words)

> $room.getSmell(0)
< It smells cheesy.

> $room.getSmell(2)
< It smells sweet.

> $room.getSmell(6)
< E_RANGE: list index 6 out of bounds (at 0 c0)
#null $8473aa60-0e99-426a-9aa2-99f3d0889d96.getSmell(6)
  #null $null.(eval)("$room.getSmell(6)")

>
```