### PR TITLE
Add simple user login

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,8 @@ dependencies {
     implementation("ch.qos.logback:logback-classic:$logback_version")
     testImplementation("io.ktor:ktor-server-test-host")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")
+
+    implementation("com.aallam.ulid:ulid-kotlin:1.3.0")
 }
 
 tasks.named<KotlinCompilationTask<*>>("compileKotlin").configure {

--- a/src/main/kotlin/Yegg.kt
+++ b/src/main/kotlin/Yegg.kt
@@ -5,6 +5,8 @@ import com.dlfsystems.world.World
 import com.dlfsystems.compiler.Compiler
 import com.dlfsystems.value.VObj
 import com.dlfsystems.value.VTrait
+import com.dlfsystems.vm.Context
+import com.dlfsystems.world.Obj
 import kotlinx.serialization.json.Json
 import java.io.File
 import kotlin.system.exitProcess
@@ -17,6 +19,8 @@ object Yegg {
         var buffer = mutableListOf<String>()
         var programming: Pair<String, String>? = null
         var quitRequested = false
+
+        var user: Obj? = null
 
         // Receive text from websocket.  Just a basic REPL for now.
         fun receiveText(text: String): String {
@@ -38,10 +42,11 @@ object Yegg {
         }
 
         // Respond to meta commands.
-        fun parseMeta(text: String): String {
+        private fun parseMeta(text: String): String {
             if (text == "@") return ""
             val words = text.split(" ")
             return when (words[0].substring(1, words[0].length)) {
+                "connect" -> parseConnect(words)
                 "program" -> parseProgram(words)
                 "list" -> parseList(words)
                 "quit" -> parseQuit(words)
@@ -49,7 +54,16 @@ object Yegg {
             }
         }
 
-        fun parseProgram(words: List<String>): String {
+        private fun parseConnect(words: List<String>): String {
+            if (words.size != 3) return "Usage: @connect <name> <password>"
+            world.getUserLogin(words[1], words[2])?.also { user ->
+                this.user = user
+                return "** Connected **"
+            }
+            return "Bad credentials."
+        }
+
+        private fun parseProgram(words: List<String>): String {
             if (words.size < 2) return "@program what?"
             val terms = words[1].split(".")
             if (terms.size != 2) return "@program what?"
@@ -57,14 +71,14 @@ object Yegg {
             return "Enter verbcode.  Terminate with '.' on a line by itself."
         }
 
-        fun parseList(words: List<String>): String {
+        private fun parseList(words: List<String>): String {
             if (words.size < 2) return "@list what?"
             val terms = words[1].split(".")
             if (terms.size != 2) return "@list what?"
             return world.listVerb(terms[0], terms[1])
         }
 
-        fun parseQuit(words: List<String>): String {
+        private fun parseQuit(words: List<String>): String {
             quitRequested = true
             return "Goodbye!"
         }
@@ -82,7 +96,10 @@ object Yegg {
         if (file.exists()) {
             Log.i("Loading database from ${file.path}...")
             try {
+                // Deserialize the world
                 world = Json.decodeFromString<World>(file.readText())
+                // Restore transient references
+                world.traits.values.forEach { it.world = world }
                 Log.i("Loaded ${world.name} with ${world.traits.size} traits and ${world.objs.size} objs.")
             } catch (e: Exception) {
                 Log.e("FATAL: Failed to load from ${file.path} !")

--- a/src/main/kotlin/Yegg.kt
+++ b/src/main/kotlin/Yegg.kt
@@ -98,8 +98,6 @@ object Yegg {
             try {
                 // Deserialize the world
                 world = Json.decodeFromString<World>(file.readText())
-                // Restore transient references
-                world.traits.values.forEach { it.world = world }
                 Log.i("Loaded ${world.name} with ${world.traits.size} traits and ${world.objs.size} objs.")
             } catch (e: Exception) {
                 Log.e("FATAL: Failed to load from ${file.path} !")

--- a/src/main/kotlin/compiler/Coder.kt
+++ b/src/main/kotlin/compiler/Coder.kt
@@ -5,7 +5,7 @@ import com.dlfsystems.vm.Opcode
 import com.dlfsystems.vm.Opcode.*
 import com.dlfsystems.vm.VMWord
 import com.dlfsystems.value.*
-import kotlin.uuid.Uuid
+import ulid.ULID
 
 class Coder(val ast: Node) {
 
@@ -38,7 +38,7 @@ class Coder(val ast: Node) {
     fun value(from: Node, boolValue: Boolean) { value(from, VBool(boolValue)) }
     fun value(from: Node, floatValue: Float) { value(from, VFloat(floatValue)) }
     fun value(from: Node, stringValue: String) { value(from, VString(stringValue)) }
-    fun value(from: Node, objValue: Uuid) { value(from, VObj(objValue)) }
+    fun value(from: Node, objValue: ULID) { value(from, VObj(objValue)) }
 
     // Write a placeholder address for a jump we'll locate in the future.
     // Nodes call this to jump to a named future address.

--- a/src/main/kotlin/compiler/ast/N_STATEMENT.kt
+++ b/src/main/kotlin/compiler/ast/N_STATEMENT.kt
@@ -2,7 +2,7 @@ package com.dlfsystems.compiler.ast
 
 import com.dlfsystems.compiler.Coder
 import com.dlfsystems.vm.Opcode.*
-import kotlin.uuid.Uuid
+import ulid.ULID
 
 // A statement which doesn't necessarily return a value.
 
@@ -60,8 +60,8 @@ class N_FORLOOP(val assign: N_STATEMENT, val check: N_EXPR, val increment: N_STA
 }
 
 class N_FORVALUE(val index: N_IDENTIFIER, val source: N_EXPR, val body: N_STATEMENT): N_STATEMENT() {
-    private val internalIndex = N_IDENTIFIER(Uuid.random().toString())
-    private val internalSource = N_IDENTIFIER(Uuid.random().toString())
+    private val internalIndex = N_IDENTIFIER(ULID.nextULID().toString())
+    private val internalSource = N_IDENTIFIER(ULID.nextULID().toString())
 
     override fun toText(depth: Int) = tab(depth) + "for ($index in $source) " + body.toText(depth + 1)
     override fun toText() = toText(0)
@@ -96,7 +96,7 @@ class N_FORVALUE(val index: N_IDENTIFIER, val source: N_EXPR, val body: N_STATEM
 }
 
 class N_FORRANGE(val index: N_IDENTIFIER, val from: N_EXPR, val to: N_EXPR, val body: N_STATEMENT): N_STATEMENT() {
-    private val internalTo = N_IDENTIFIER(Uuid.random().toString())
+    private val internalTo = N_IDENTIFIER(ULID.nextULID().toString())
 
     override fun toText(depth: Int) = tab(depth) + "for ($index in $from..$to) " + body.toText(depth + 1)
     override fun toText() = toText(0)

--- a/src/main/kotlin/compiler/ast/Node.kt
+++ b/src/main/kotlin/compiler/ast/Node.kt
@@ -2,12 +2,12 @@ package com.dlfsystems.compiler.ast
 
 import com.dlfsystems.compiler.Coder
 import com.dlfsystems.compiler.CompileException
-import kotlin.uuid.Uuid
+import ulid.ULID
 
 // A node in the syntax tree.
 
 abstract class Node {
-    val id = Uuid.random()
+    val id = ULID.nextULID()
 
     var lineNum = 0
     var charNum = 0

--- a/src/main/kotlin/value/VObj.kt
+++ b/src/main/kotlin/value/VObj.kt
@@ -3,10 +3,10 @@ package com.dlfsystems.value
 import com.dlfsystems.vm.Context
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlin.uuid.Uuid
+import ulid.ULID
 
 @Serializable
-data class VObj(val v: Uuid?): Value() {
+data class VObj(val v: ULID?): Value() {
 
     @SerialName("yType")
     override val type = Type.OBJ

--- a/src/main/kotlin/value/VObj.kt
+++ b/src/main/kotlin/value/VObj.kt
@@ -23,11 +23,15 @@ data class VObj(val v: Uuid?): Value() {
     override fun getProp(c: Context, name: String): Value? {
         when (name) {
             "asString" -> return propAsString()
+            "traits" -> return propTraits(c)
         }
-        return null
+        return v?.let { c.getObj(it)?.getProp(c, name) }
     }
 
     override fun setProp(c: Context, name: String, value: Value): Boolean {
+        c.getObj(v)?.also { obj ->
+            return obj.setProp(c, name, value)
+        }
         return false
     }
 
@@ -35,6 +39,10 @@ data class VObj(val v: Uuid?): Value() {
     // Custom props
 
     private fun propAsString() = VString(toString())
+
+    private fun propTraits(c: Context) = VList((
+        v?.let { c.getObj(it)?.traits?.map { VTrait(it) } } ?: mutableListOf()
+    ).toMutableList())
 
     // Custom verbs
 

--- a/src/main/kotlin/value/VTrait.kt
+++ b/src/main/kotlin/value/VTrait.kt
@@ -3,10 +3,10 @@ package com.dlfsystems.value
 import com.dlfsystems.vm.Context
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlin.uuid.Uuid
+import ulid.ULID
 
 @Serializable
-data class VTrait(val v: Uuid?): Value() {
+data class VTrait(val v: ULID?): Value() {
 
     @SerialName("yType")
     override val type = Type.TRAIT

--- a/src/main/kotlin/vm/Context.kt
+++ b/src/main/kotlin/vm/Context.kt
@@ -3,7 +3,7 @@ package com.dlfsystems.vm
 import com.dlfsystems.Yegg
 import com.dlfsystems.world.World
 import com.dlfsystems.value.*
-import kotlin.uuid.Uuid
+import ulid.ULID
 
 // Variables from the world which a VM uses to execute a func.
 // A persistent VM will own a context whose values are updated from outside it.
@@ -34,8 +34,8 @@ class Context(
         callStack.removeFirst()
 
     fun getTrait(name: String) = world.getTrait(name)
-    fun getTrait(id: Uuid?) = id?.let { world.getTrait(id) }
-    fun getObj(id: Uuid?) = id?.let { world.getObj(id) }
+    fun getTrait(id: ULID?) = id?.let { world.getTrait(id) }
+    fun getObj(id: ULID?) = id?.let { world.getObj(id) }
 
     fun stackDump() = callStack.joinToString(separator = "\n  ", postfix = "\n")
 }

--- a/src/main/kotlin/vm/Context.kt
+++ b/src/main/kotlin/vm/Context.kt
@@ -34,7 +34,8 @@ class Context(
         callStack.removeFirst()
 
     fun getTrait(name: String) = world.getTrait(name)
-    fun getTrait(id: Uuid) = world.getTrait(id)
+    fun getTrait(id: Uuid?) = id?.let { world.getTrait(id) }
+    fun getObj(id: Uuid?) = id?.let { world.getObj(id) }
 
     fun stackDump() = callStack.joinToString(separator = "\n  ", postfix = "\n")
 }

--- a/src/main/kotlin/world/Obj.kt
+++ b/src/main/kotlin/world/Obj.kt
@@ -1,8 +1,11 @@
 package com.dlfsystems.world
 
+import com.dlfsystems.value.VList
 import com.dlfsystems.value.VObj
+import com.dlfsystems.value.VTrait
 import com.dlfsystems.value.Value
 import com.dlfsystems.vm.Context
+import com.dlfsystems.world.trait.Trait
 import kotlinx.serialization.Serializable
 import kotlin.uuid.Uuid
 
@@ -12,8 +15,44 @@ import kotlin.uuid.Uuid
 class Obj {
 
     val id: Uuid = Uuid.random()
-    private val vThis = VObj(id)
+    val vThis = VObj(id)
 
     val traits: MutableList<Uuid> = mutableListOf()
+
+    val props: MutableMap<String, Value> = mutableMapOf()
+
+    fun acquireTrait(trait: Trait) {
+        traits.add(trait.id)
+    }
+
+    fun dispelTrait(trait: Trait) {
+        trait.props.keys.forEach { props.remove(it) }
+        traits.remove(trait.id)
+    }
+
+    fun getProp(c: Context, name: String): Value? {
+        props[name]?.also { return it }
+
+        traits.forEach {
+            c.getTrait(it)?.getProp(c, name)?.also { return it }
+        }
+        return null
+    }
+
+    fun setProp(c: Context, name: String, value: Value): Boolean {
+        if (hasProp(c, name)) {
+            props[name] = value
+            return true
+        }
+        return false
+    }
+
+    fun hasProp(c: Context, name: String): Boolean {
+        if (name in props.keys) return true
+        traits.forEach { traitID ->
+            if (name in (c.getTrait(traitID)?.props?.keys ?: listOf())) return true
+        }
+        return false
+    }
 
 }

--- a/src/main/kotlin/world/Obj.kt
+++ b/src/main/kotlin/world/Obj.kt
@@ -1,23 +1,21 @@
 package com.dlfsystems.world
 
-import com.dlfsystems.value.VList
 import com.dlfsystems.value.VObj
-import com.dlfsystems.value.VTrait
 import com.dlfsystems.value.Value
 import com.dlfsystems.vm.Context
 import com.dlfsystems.world.trait.Trait
 import kotlinx.serialization.Serializable
-import kotlin.uuid.Uuid
+import ulid.ULID
 
 // An instance in the world.
 
 @Serializable
 class Obj {
 
-    val id: Uuid = Uuid.random()
+    val id: ULID = ULID.nextULID()
     val vThis = VObj(id)
 
-    val traits: MutableList<Uuid> = mutableListOf()
+    val traits: MutableList<ULID> = mutableListOf()
 
     val props: MutableMap<String, Value> = mutableMapOf()
 

--- a/src/main/kotlin/world/World.kt
+++ b/src/main/kotlin/world/World.kt
@@ -7,18 +7,18 @@ import com.dlfsystems.vm.Context
 import com.dlfsystems.world.trait.SysTrait
 import com.dlfsystems.world.trait.Trait
 import com.dlfsystems.world.trait.UserTrait
-import kotlin.uuid.Uuid
 import kotlinx.serialization.Serializable
+import ulid.ULID
 
 @Serializable
 data class World(
     val name: String = "world"
 ) {
 
-    val traits: MutableMap<Uuid, Trait> = mutableMapOf()
-    val traitIDs: MutableMap<String, Uuid> = mutableMapOf()
+    val traits: MutableMap<ULID, Trait> = mutableMapOf()
+    val traitIDs: MutableMap<String, ULID> = mutableMapOf()
 
-    val objs: MutableMap<Uuid, Obj> = mutableMapOf()
+    val objs: MutableMap<ULID, Obj> = mutableMapOf()
 
     fun getUserLogin(name: String, password: String): Obj? {
         val c = Context(this)
@@ -37,8 +37,8 @@ data class World(
     }
 
     fun getTrait(named: String) = traits[traitIDs[named]]
-    fun getTrait(id: Uuid) = traits[id]
-    fun getObj(id: Uuid) = objs[id]
+    fun getTrait(id: ULID) = traits[id]
+    fun getObj(id: ULID) = objs[id]
 
     fun getSysValue(c: Context, name: String): Value = getTrait("sys")!!.getProp(c, name)!!
 
@@ -59,16 +59,16 @@ data class World(
 
     fun createObj() = Obj().also { objs[it.id] = it }
 
-    fun recycleObj(objID: Uuid) {
+    fun recycleObj(objID: ULID) {
         objs[objID]?.traits?.forEach { getTrait(it)?.removeFrom(objs[objID]!!) }
         objs.remove(objID)
     }
 
-    fun applyTrait(traitID: Uuid, objID: Uuid) {
+    fun applyTrait(traitID: ULID, objID: ULID) {
         traits[traitID]?.applyTo(objs[objID]!!)
     }
 
-    fun dispelTrait(traitID: Uuid, objID: Uuid) {
+    fun dispelTrait(traitID: ULID, objID: ULID) {
         traits[traitID]?.removeFrom(objs[objID]!!)
     }
 

--- a/src/main/kotlin/world/World.kt
+++ b/src/main/kotlin/world/World.kt
@@ -49,7 +49,6 @@ data class World(
                 "user" -> UserTrait()
                 else -> Trait(name)
             }.also {
-                it.world = this
                 traits[it.id] = it
                 traitIDs[it.name] = it.id
             }

--- a/src/main/kotlin/world/trait/SysTrait.kt
+++ b/src/main/kotlin/world/trait/SysTrait.kt
@@ -1,10 +1,7 @@
 package com.dlfsystems.world.trait
 
 import com.dlfsystems.Yegg
-import com.dlfsystems.value.VInt
-import com.dlfsystems.value.VString
-import com.dlfsystems.value.VVoid
-import com.dlfsystems.value.Value
+import com.dlfsystems.value.*
 import com.dlfsystems.vm.Context
 
 // A special trait which exists in every world.
@@ -28,6 +25,7 @@ class SysTrait : Trait("sys") {
     override fun callVerb(c: Context, verbName: String, args: List<Value>): Value? {
         when (verbName) {
             "addTrait" -> return verbAddTrait(c, args)
+            "create" -> return verbCreate(c, args)
             "dumpDatabase" -> return verbDumpDatabase(c, args)
         }
         return super.callVerb(c, verbName, args)
@@ -37,6 +35,20 @@ class SysTrait : Trait("sys") {
         if (args.size != 1 || args[0] !is VString) throw IllegalArgumentException("Bad args for addTrait")
         c.world.addTrait(args[0].asString())
         return VVoid()
+    }
+
+    private fun verbCreate(c: Context, args: List<Value>): Value {
+        val obj = c.world.createObj()
+        try {
+            args.forEach {
+                if (it !is VTrait) throw IllegalArgumentException("Non-trait passed to create")
+                c.world.applyTrait(it.v!!, obj.id)
+            }
+            return VObj(obj.id)
+        } catch (e: Exception) {
+            c.world.recycleObj(obj.id)
+            throw e
+        }
     }
 
     private fun verbDumpDatabase(c: Context, args: List<Value>): Value {

--- a/src/main/kotlin/world/trait/Trait.kt
+++ b/src/main/kotlin/world/trait/Trait.kt
@@ -3,10 +3,15 @@ package com.dlfsystems.world.trait
 import com.dlfsystems.Yegg
 import com.dlfsystems.app.Log
 import com.dlfsystems.compiler.Compiler
+import com.dlfsystems.value.VList
+import com.dlfsystems.value.VObj
 import com.dlfsystems.value.VTrait
 import com.dlfsystems.value.Value
 import com.dlfsystems.vm.Context
+import com.dlfsystems.world.Obj
+import com.dlfsystems.world.World
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 import kotlin.uuid.Uuid
 
 // A collection of verbs and props, which can apply to an Obj.
@@ -14,11 +19,33 @@ import kotlin.uuid.Uuid
 @Serializable
 open class Trait(val name: String) {
 
+    @Transient lateinit var world: World
+
     val id: Uuid = Uuid.random()
     private val vTrait = VTrait(id)
 
+    val traits: MutableList<Uuid> = mutableListOf()
+
     val verbs: MutableMap<String, Verb> = mutableMapOf()
     open val props: MutableMap<String, Value> = mutableMapOf()
+
+    val objects: MutableSet<Uuid> = mutableSetOf()
+
+    fun applyTo(obj: Obj) {
+        obj.traits.forEach {
+            if (world.getTrait(it)?.hasTrait(this.id) == true)
+                throw IllegalArgumentException("obj already inherits trait")
+        }
+        objects.add(obj.id)
+        obj.acquireTrait(this)
+    }
+
+    fun removeFrom(obj: Obj) {
+        objects.remove(obj.id)
+        obj.dispelTrait(this)
+    }
+
+    fun hasTrait(trait: Uuid): Boolean = (trait in traits) || (traits.first { world.getTrait(it)?.hasTrait(trait) ?: false } != null)
 
     fun programVerb(verbName: String, cOut: Compiler.Result) {
         verbs[verbName]?.also {
@@ -28,7 +55,13 @@ open class Trait(val name: String) {
         }
     }
 
-    open fun getProp(c: Context, propName: String): Value? = props.getOrDefault(propName, null)
+    open fun getProp(c: Context, propName: String): Value? {
+        return when (propName) {
+            "objects" -> return VList(objects.map { VObj(it) }.toMutableList())
+            else -> props.getOrDefault(propName, null)
+        }
+    }
+
     open fun setProp(c: Context, propName: String, value: Value): Boolean {
         props[propName] = value
         return true

--- a/src/main/kotlin/world/trait/Trait.kt
+++ b/src/main/kotlin/world/trait/Trait.kt
@@ -9,17 +9,13 @@ import com.dlfsystems.value.VTrait
 import com.dlfsystems.value.Value
 import com.dlfsystems.vm.Context
 import com.dlfsystems.world.Obj
-import com.dlfsystems.world.World
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.Transient
 import ulid.ULID
 
 // A collection of verbs and props, which can apply to an Obj.
 
 @Serializable
 open class Trait(val name: String) {
-
-    @Transient lateinit var world: World
 
     val id: ULID = ULID.nextULID()
     private val vTrait = VTrait(id)
@@ -33,7 +29,7 @@ open class Trait(val name: String) {
 
     fun applyTo(obj: Obj) {
         obj.traits.forEach {
-            if (world.getTrait(it)?.hasTrait(this.id) == true)
+            if (Yegg.world.getTrait(it)?.hasTrait(this.id) == true)
                 throw IllegalArgumentException("obj already inherits trait")
         }
         objects.add(obj.id)
@@ -45,7 +41,7 @@ open class Trait(val name: String) {
         obj.dispelTrait(this)
     }
 
-    fun hasTrait(trait: ULID): Boolean = (trait in traits) || (traits.first { world.getTrait(it)?.hasTrait(trait) ?: false } != null)
+    fun hasTrait(trait: ULID): Boolean = (trait in traits) || (traits.first { Yegg.world.getTrait(it)?.hasTrait(trait) ?: false } != null)
 
     fun programVerb(verbName: String, cOut: Compiler.Result) {
         verbs[verbName]?.also {

--- a/src/main/kotlin/world/trait/Trait.kt
+++ b/src/main/kotlin/world/trait/Trait.kt
@@ -12,7 +12,7 @@ import com.dlfsystems.world.Obj
 import com.dlfsystems.world.World
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
-import kotlin.uuid.Uuid
+import ulid.ULID
 
 // A collection of verbs and props, which can apply to an Obj.
 
@@ -21,15 +21,15 @@ open class Trait(val name: String) {
 
     @Transient lateinit var world: World
 
-    val id: Uuid = Uuid.random()
+    val id: ULID = ULID.nextULID()
     private val vTrait = VTrait(id)
 
-    val traits: MutableList<Uuid> = mutableListOf()
+    val traits: MutableList<ULID> = mutableListOf()
 
     val verbs: MutableMap<String, Verb> = mutableMapOf()
     open val props: MutableMap<String, Value> = mutableMapOf()
 
-    val objects: MutableSet<Uuid> = mutableSetOf()
+    val objects: MutableSet<ULID> = mutableSetOf()
 
     fun applyTo(obj: Obj) {
         obj.traits.forEach {
@@ -45,7 +45,7 @@ open class Trait(val name: String) {
         obj.dispelTrait(this)
     }
 
-    fun hasTrait(trait: Uuid): Boolean = (trait in traits) || (traits.first { world.getTrait(it)?.hasTrait(trait) ?: false } != null)
+    fun hasTrait(trait: ULID): Boolean = (trait in traits) || (traits.first { world.getTrait(it)?.hasTrait(trait) ?: false } != null)
 
     fun programVerb(verbName: String, cOut: Compiler.Result) {
         verbs[verbName]?.also {

--- a/src/main/kotlin/world/trait/UserTrait.kt
+++ b/src/main/kotlin/world/trait/UserTrait.kt
@@ -1,0 +1,13 @@
+package com.dlfsystems.world.trait
+
+import com.dlfsystems.value.VString
+import com.dlfsystems.value.Value
+
+class UserTrait : Trait("user") {
+
+    override val props = mutableMapOf<String, Value>(
+        "username" to VString(""),
+        "password" to VString(""),
+    )
+
+}


### PR DESCRIPTION
This adds a few small but fundamental things to allow a simple user login:

- Switch from UUID to ULID for obj and trait IDs.  (not necessary but good)

- Traits now get a transient reference back to the World they're a part of.  This is mostly a convenience to allow methods on traits to be aware of other traits in their inheritance chain, without being passed a Context.  This wasn't strictly necessary and might be a bad idea.

- A DB obj can now have traits, and adding a trait checks for circular inheritance.

- A second built-in trait: $user, representing a user with login/password.  This needs to exist so login can check against something.  This could have been done in-DB but seems so fundamental it's worth doing this way.

- $sys.create($trait, $trait...) to create a new DB obj.

- $trait.objects tracks all objects which inherit that trait.

```
> $sys.first = $sys.create($user)
<
> $sys.first.username = "Gilmore"
<
> $sys.first.password = "bluguuru"
<
> @connect Gilmore bluguuru
< ** Connected **
>
```