### PR TITLE
Spread Assign and Obj Literal

### DIFF
--- a/src/main/kotlin/compiler/Lexer.kt
+++ b/src/main/kotlin/compiler/Lexer.kt
@@ -1,6 +1,7 @@
 package com.dlfsystems.compiler
 
 import com.dlfsystems.compiler.TokenType.*
+import com.dlfsystems.server.Yegg
 
 // Take an input string and produce a stream of tokens.
 
@@ -127,6 +128,9 @@ class Lexer(val source: String) {
                 in '0'..'9' -> accumulate(c)
                 else -> emit(T_FLOAT, c)
             }
+            T_OBJREF -> {
+                if (isIDChar(c)) accumulate(c) else emit(T_OBJREF, c)
+            }
             T_IDENTIFIER -> {
                 if (isIdentifierChar(c)) accumulate(c) else emit(T_IDENTIFIER, c)
             }
@@ -137,6 +141,7 @@ class Lexer(val source: String) {
                     '}' -> if (inStringCodesub) { emit(T_STRING_SUB_END) ; begin(T_STRING) ; inStringCodesub = false }
                             else emit(T_BRACE_CLOSE)
                     '"' -> begin(T_STRING)
+                    '#' -> begin(T_OBJREF)
                     '=' -> begin(T_ASSIGN)
                     '>' -> begin(T_GREATER_THAN)
                     '<' -> begin(T_LESS_THAN)
@@ -176,6 +181,9 @@ class Lexer(val source: String) {
 
     // Is this a legal char for an identifier name?
     private fun isIdentifierChar(c: Char) = (c in 'a'..'z') || (c in 'A'..'Z') || (c in '0'..'9') || (c == '_')
+
+    // Is this a legal char for an internal ID string?
+    private fun isIDChar(c: Char) = Yegg.idChars.contains(c)
 
     // Begin a new accumulating token of (possibly) type.  Start with acc if given.
     private fun begin(type: TokenType, acc: Char? = null) {

--- a/src/main/kotlin/compiler/Parser.kt
+++ b/src/main/kotlin/compiler/Parser.kt
@@ -75,7 +75,7 @@ class Parser(inputTokens: List<Token>) {
         pReturn()?.also { return it }
         pFail()?.also { return it }
         pIncrement()?.also { return it }
-        pSpreadAssign()?.also { return it }
+        pDestructureList()?.also { return it }
         pAssign()?.also { return it }
         pExprStatement()?.also { return it }
         return null
@@ -229,15 +229,15 @@ class Parser(inputTokens: List<Token>) {
         return null
     }
 
-    // Parse spread assign: [var1, var2...] = list
-    private fun pSpreadAssign(): N_STATEMENT? {
+    // Parse list destructure: [var1, var2...] = list
+    private fun pDestructureList(): N_STATEMENT? {
         if (nextIs(T_BRACKET_OPEN)) {
             var i = 1
             var done = false
             while (!done) {
                 if (nextToken(i).type != T_IDENTIFIER) return null
                 if (nextToken(i+1).type == T_BRACKET_CLOSE) done = true
-                else if (nextToken(i+1).type != T_COMMA) fail("spread assign list must contain only variable names")
+                else if (nextToken(i+1).type != T_COMMA) fail("destructure list must contain only variable names")
                 i += 2
             }
             if (nextToken(i).type != T_ASSIGN) return null
@@ -254,8 +254,8 @@ class Parser(inputTokens: List<Token>) {
             }
             consume(T_ASSIGN)
             pExpression()?.also { right ->
-                return node(N_SPREAD(vars, right))
-            } ?: fail("expression missing for spread assign")
+                return node(N_DESTRUCT(vars, right))
+            } ?: fail("expression missing for list destructure")
         }
         return null
     }

--- a/src/main/kotlin/compiler/Parser.kt
+++ b/src/main/kotlin/compiler/Parser.kt
@@ -4,6 +4,7 @@ package com.dlfsystems.compiler
 
 import com.dlfsystems.compiler.TokenType.*
 import com.dlfsystems.compiler.ast.*
+import com.dlfsystems.world.ObjID
 
 // Take a stream of input tokens from Lexer and produce a tree of syntax nodes.
 
@@ -525,6 +526,7 @@ class Parser(inputTokens: List<Token>) {
         consume(T_STRING)?.also { return node(N_LITERAL_STRING(it.string)) }
         consume(T_INTEGER)?.also { return node(N_LITERAL_INTEGER(it.string.toInt())) }
         consume(T_FLOAT)?.also { return node(N_LITERAL_FLOAT(it.string.toFloat())) }
+        consume(T_OBJREF)?.also { return node(N_LITERAL_OBJ(ObjID(it.string))) }
         consume(T_IDENTIFIER)?.also { return node(N_IDENTIFIER(it.string)) }
         consume(T_TRUE, T_FALSE)?.also { return node(N_LITERAL_BOOLEAN(it.type == T_TRUE)) }
         return next()

--- a/src/main/kotlin/compiler/Token.kt
+++ b/src/main/kotlin/compiler/Token.kt
@@ -50,6 +50,7 @@ enum class TokenType(val literal: String, val isKeyword: Boolean = false) {
     T_STRING_SUB_END("}"),
     T_INTEGER("n"),
     T_FLOAT("n.n"),
+    T_OBJREF("#xxxxx"),
 
     // Keywords
     T_AND("and", true),

--- a/src/main/kotlin/compiler/ast/N_LITERAL.kt
+++ b/src/main/kotlin/compiler/ast/N_LITERAL.kt
@@ -3,6 +3,7 @@ package com.dlfsystems.compiler.ast
 import com.dlfsystems.compiler.Coder
 import com.dlfsystems.value.VString
 import com.dlfsystems.vm.Opcode.*
+import com.dlfsystems.world.ObjID
 
 // A literal value appearing in code.
 
@@ -28,6 +29,11 @@ class N_LITERAL_INTEGER(val value: Int): N_LITERAL() {
 class N_LITERAL_FLOAT(val value: Float): N_LITERAL() {
     override fun toText() = "$value"
     override fun codeValue(coder: Coder) { coder.value(this, value) }
+}
+
+class N_LITERAL_OBJ(val objID: ObjID): N_LITERAL() {
+    override fun toText() = "#$id"
+    override fun codeValue(coder: Coder) { coder.value(this, objID) }
 }
 
 class N_LITERAL_STRING(val value: String): N_LITERAL() {

--- a/src/main/kotlin/compiler/ast/N_STATEMENT.kt
+++ b/src/main/kotlin/compiler/ast/N_STATEMENT.kt
@@ -1,6 +1,7 @@
 package com.dlfsystems.compiler.ast
 
 import com.dlfsystems.compiler.Coder
+import com.dlfsystems.value.VString
 import com.dlfsystems.vm.Opcode.*
 
 // A statement which doesn't necessarily return a value.
@@ -16,6 +17,18 @@ class N_ASSIGN(val left: N_EXPR, val right: N_EXPR): N_STATEMENT() {
     override fun code(coder: Coder) {
         right.code(coder)
         left.codeAssign(coder)
+    }
+}
+
+class N_SPREAD(val vars: List<N_IDENTIFIER>, val right: N_EXPR): N_STATEMENT() {
+    override fun toText() = "[${vars.joinToString(",")}] = $right"
+    override fun kids() = vars + listOf(right)
+
+    override fun code(coder: Coder) {
+        coder.code(this, O_VAL)
+        coder.value(this, vars.map { VString(it.name) })
+        right.code(coder)
+        coder.code(this, O_SPREAD)
     }
 }
 

--- a/src/main/kotlin/compiler/ast/N_STATEMENT.kt
+++ b/src/main/kotlin/compiler/ast/N_STATEMENT.kt
@@ -20,7 +20,7 @@ class N_ASSIGN(val left: N_EXPR, val right: N_EXPR): N_STATEMENT() {
     }
 }
 
-class N_SPREAD(val vars: List<N_IDENTIFIER>, val right: N_EXPR): N_STATEMENT() {
+class N_DESTRUCT(val vars: List<N_IDENTIFIER>, val right: N_EXPR): N_STATEMENT() {
     override fun toText() = "[${vars.joinToString(",")}] = $right"
     override fun kids() = vars + listOf(right)
 
@@ -28,7 +28,7 @@ class N_SPREAD(val vars: List<N_IDENTIFIER>, val right: N_EXPR): N_STATEMENT() {
         coder.code(this, O_VAL)
         coder.value(this, vars.map { VString(it.name) })
         right.code(coder)
-        coder.code(this, O_SPREAD)
+        coder.code(this, O_DESTRUCT)
     }
 }
 

--- a/src/main/kotlin/server/Yegg.kt
+++ b/src/main/kotlin/server/Yegg.kt
@@ -31,7 +31,8 @@ object Yegg {
     private val connections = mutableSetOf<Connection>()
     val connectedUsers = mutableMapOf<Obj, Connection>()
 
-    fun newID() = NanoId.generateOptimized(8, "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", 61, 16)
+    val idChars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    fun newID() = NanoId.generateOptimized(8, idChars, 61, 16)
 
     fun start() {
         val file = File("$worldName.yegg")

--- a/src/main/kotlin/vm/Opcode.kt
+++ b/src/main/kotlin/vm/Opcode.kt
@@ -63,8 +63,8 @@ enum class Opcode(val argCount: Int = 0) {
     // Set range pop2..pop1 of value pop0.
     O_SETRANGE,
 
-    // Spread-assign pop1 list to pop2 list of varnames.
-    O_SPREAD,
+    // Assign pop1 list's elements to pop2 list of varnames.
+    O_DESTRUCT,
 
     // Push iterableSize of pop0 as VInt.
     O_ITERSIZE,

--- a/src/main/kotlin/vm/Opcode.kt
+++ b/src/main/kotlin/vm/Opcode.kt
@@ -63,6 +63,9 @@ enum class Opcode(val argCount: Int = 0) {
     // Set range pop2..pop1 of value pop0.
     O_SETRANGE,
 
+    // Spread-assign pop1 list to pop2 list of varnames.
+    O_SPREAD,
+
     // Push iterableSize of pop0 as VInt.
     O_ITERSIZE,
 

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -211,9 +211,9 @@ class VM(val verb: Verb) {
                         else fail(E_TYPE, "cannot increment ${it.type}")
                     } ?: fail(E_VARNF, "variable not found")
                 }
-                O_SPREAD -> {
+                O_DESTRUCT -> {
                     val (a2, a1) = popTwo()
-                    if (a2 !is VList) fail(E_TYPE, "cannot spread assign from non-list")
+                    if (a2 !is VList) fail(E_TYPE, "cannot destructure from non-list")
                     if ((a2 as VList).v.size < (a1 as VList).v.size) fail(E_RANGE, "missing args")
                     a1.v.forEachIndexed { i, vn ->
                         verb.symbols[(vn as VString).v]?.also { variables[it] = a2.v[i] }

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -211,6 +211,14 @@ class VM(val verb: Verb) {
                         else fail(E_TYPE, "cannot increment ${it.type}")
                     } ?: fail(E_VARNF, "variable not found")
                 }
+                O_SPREAD -> {
+                    val (a2, a1) = popTwo()
+                    if (a2 !is VList) fail(E_TYPE, "cannot spread assign from non-list")
+                    if ((a2 as VList).v.size < (a1 as VList).v.size) fail(E_RANGE, "missing args")
+                    a1.v.forEachIndexed { i, vn ->
+                        verb.symbols[(vn as VString).v]?.also { variables[it] = a2.v[i] }
+                    }
+                }
 
                 // Iterator ops
 


### PR DESCRIPTION
Two simple but handy bits of syntax:

### Spread assign
```
[foo, bar, baz] = args
```
Handy for dereferencing an arg list, but could be used with any list anywhere.

### Object literals
```
this.thing = #x7Yqu
```
Hopefully this won't see much use, but it is handy while debugging.  It occurred to me we could support "vanity objnums" in the future like: mySingleton = $sys.create(objID = "World"), so you could have important objects that can be conveniently referenced by their typeable objnum (#World).  Seems wacky though...
