### PR TITLE
Reduce constant expressions

### DIFF
--- a/src/main/kotlin/compiler/ast/N_BINOP.kt
+++ b/src/main/kotlin/compiler/ast/N_BINOP.kt
@@ -1,6 +1,8 @@
 package com.dlfsystems.compiler.ast
 
 import com.dlfsystems.compiler.Coder
+import com.dlfsystems.value.VVoid
+import com.dlfsystems.value.Value
 import com.dlfsystems.vm.Opcode
 import com.dlfsystems.vm.Opcode.*
 
@@ -9,20 +11,42 @@ import com.dlfsystems.vm.Opcode.*
 abstract class N_BINOP(val opString: String, val left: N_EXPR, val right: N_EXPR, val ops: List<Opcode>): N_EXPR() {
     override fun toText() = "($left $opString $right)"
     override fun kids() = listOf(left, right)
+    override fun constantValue(): Value? {
+        left.constantValue()?.also { leftConstant ->
+            right.constantValue()?.also { rightConstant ->
+                asConstant(leftConstant, rightConstant)?.also { return it }
+            }
+        }
+        return null
+    }
+    open fun asConstant(l: Value, r: Value): Value? = null
 
     override fun code(coder: Coder) {
+        if (codeConstant(coder)) return
         left.code(coder)
         right.code(coder)
         ops.forEach { coder.code(this, it) }
     }
 }
 
-class N_ADD(left: N_EXPR, right: N_EXPR): N_BINOP("+", left, right, listOf(O_ADD))
-class N_SUBTRACT(left: N_EXPR, right: N_EXPR): N_BINOP("-", left, right, listOf(O_NEGATE, O_ADD))
-class N_MULTIPLY(left: N_EXPR, right: N_EXPR): N_BINOP("*", left, right, listOf(O_MULT))
-class N_DIVIDE(left: N_EXPR, right: N_EXPR): N_BINOP("/", left, right, listOf(O_DIV))
-class N_POWER(left: N_EXPR, right: N_EXPR): N_BINOP("^", left, right, listOf(O_POWER))
-class N_MODULUS(left: N_EXPR, right: N_EXPR): N_BINOP("%", left, right, listOf(O_MODULUS))
+class N_ADD(left: N_EXPR, right: N_EXPR): N_BINOP("+", left, right, listOf(O_ADD)) {
+    override fun asConstant(l: Value, r: Value) = l.plus(r)
+}
+class N_SUBTRACT(left: N_EXPR, right: N_EXPR): N_BINOP("-", left, right, listOf(O_NEGATE, O_ADD)) {
+    override fun asConstant(l: Value, r: Value) = l.plus(r.negate() ?: VVoid)
+}
+class N_MULTIPLY(left: N_EXPR, right: N_EXPR): N_BINOP("*", left, right, listOf(O_MULT))  {
+    override fun asConstant(l: Value, r: Value) = l.multiply(r)
+}
+class N_DIVIDE(left: N_EXPR, right: N_EXPR): N_BINOP("/", left, right, listOf(O_DIV)) {
+    override fun asConstant(l: Value, r: Value) = l.divide(r)
+}
+class N_POWER(left: N_EXPR, right: N_EXPR): N_BINOP("^", left, right, listOf(O_POWER)) {
+    override fun asConstant(l: Value, r: Value) = l.toPower(r)
+}
+class N_MODULUS(left: N_EXPR, right: N_EXPR): N_BINOP("%", left, right, listOf(O_MODULUS)) {
+    override fun asConstant(l: Value, r: Value) = l.modulo(r)
+}
 class N_AND(left: N_EXPR, right: N_EXPR): N_BINOP("&&", left, right, listOf(O_AND))
 class N_OR(left: N_EXPR, right: N_EXPR): N_BINOP("||", left, right, listOf(O_OR))
 class N_IN(left: N_EXPR, right: N_EXPR): N_BINOP("in", left, right, listOf(O_IN))

--- a/src/main/kotlin/compiler/ast/N_EXPR.kt
+++ b/src/main/kotlin/compiler/ast/N_EXPR.kt
@@ -13,7 +13,8 @@ abstract class N_EXPR: N_STATEMENT() {
     open fun codeIndexAssign(coder: Coder) { fail("illegal left side of index assignment") }
     // Does this expr have a constant value?
     open fun constantValue(): Value? = null
-
+    // If we have a constantValue(), code it and return true.
+    // Any code() on an N_EXPR that can have a constant value should call this first (and terminate if true).
     protected fun codeConstant(coder: Coder): Boolean {
         constantValue()?.also { value ->
             coder.code(this, O_VAL)

--- a/src/main/kotlin/compiler/ast/N_EXPR.kt
+++ b/src/main/kotlin/compiler/ast/N_EXPR.kt
@@ -1,6 +1,7 @@
 package com.dlfsystems.compiler.ast
 
 import com.dlfsystems.compiler.Coder
+import com.dlfsystems.value.Value
 import com.dlfsystems.vm.Opcode.*
 
 // An expression which reduces to a Value.
@@ -10,14 +11,27 @@ abstract class N_EXPR: N_STATEMENT() {
     open fun codeAssign(coder: Coder) { fail("illegal left side of assignment") }
     // Code this expr as the left side of [i]= assign.
     open fun codeIndexAssign(coder: Coder) { fail("illegal left side of index assignment") }
+    // Does this expr have a constant value?
+    open fun constantValue(): Value? = null
+
+    protected fun codeConstant(coder: Coder): Boolean {
+        constantValue()?.also { value ->
+            coder.code(this, O_VAL)
+            coder.value(this, value)
+            return true
+        }
+        return false
+    }
 }
 
 // Parenthetical expressions are parsed to N_PARENS to prevent X.(identifier) from binding as a literal reference.
 class N_PARENS(val expr: N_EXPR): N_EXPR() {
     override fun toText() = "($expr)"
     override fun kids() = listOf(expr)
+    override fun constantValue() = expr.constantValue()
 
     override fun code(coder: Coder) {
+        if (codeConstant(coder)) return
         expr.code(coder)
     }
 }
@@ -26,8 +40,10 @@ class N_PARENS(val expr: N_EXPR): N_EXPR() {
 class N_NEGATE(val expr: N_EXPR): N_EXPR() {
     override fun toText() = "-$expr"
     override fun kids() = listOf(expr)
+    override fun constantValue() = expr.constantValue()?.negate()
 
     override fun code(coder: Coder) {
+        if (codeConstant(coder)) return
         expr.code(coder)
         coder.code(this, O_NEGATE)
     }

--- a/src/main/kotlin/compiler/ast/N_LITERAL.kt
+++ b/src/main/kotlin/compiler/ast/N_LITERAL.kt
@@ -51,7 +51,7 @@ class N_LITERAL_LIST(val value: List<N_EXPR>): N_LITERAL() {
     override fun toText() = value.joinToString(", ", "LIST[", "]")
     override fun constantValue(): Value? {
         val constant = mutableListOf<Value>()
-        value.forEach { expr ->
+        for (expr in value) {
             val exprConstant = expr.constantValue()
             if (exprConstant == null) return null else constant.add(exprConstant)
         }
@@ -70,7 +70,7 @@ class N_LITERAL_MAP(val value: Map<N_EXPR, N_EXPR>): N_LITERAL() {
     override fun toText() = value.keys.joinToString(", ", "MAP[", "]") { "$it: ${value[it]}" }
     override fun constantValue(): Value? {
         val constant = mutableMapOf<Value, Value>()
-        value.keys.forEach { key ->
+        for (key in value.keys) {
             val keyConstant = key.constantValue()
             if (keyConstant == null) return null else {
                 val valConstant = value[key]!!.constantValue()

--- a/src/main/kotlin/compiler/ast/N_LITERAL.kt
+++ b/src/main/kotlin/compiler/ast/N_LITERAL.kt
@@ -1,7 +1,7 @@
 package com.dlfsystems.compiler.ast
 
 import com.dlfsystems.compiler.Coder
-import com.dlfsystems.value.VString
+import com.dlfsystems.value.*
 import com.dlfsystems.vm.Opcode.*
 import com.dlfsystems.world.ObjID
 
@@ -19,32 +19,46 @@ abstract class N_LITERAL: N_EXPR() {
 class N_LITERAL_BOOLEAN(val value: Boolean): N_LITERAL() {
     override fun toText() = if (value) "true" else "false"
     override fun codeValue(coder: Coder) { coder.value(this, value) }
+    override fun constantValue() = VBool(value)
 }
 
 class N_LITERAL_INTEGER(val value: Int): N_LITERAL() {
     override fun toText() = "$value"
     override fun codeValue(coder: Coder) { coder.value(this, value) }
+    override fun constantValue() = VInt(value)
 }
 
 class N_LITERAL_FLOAT(val value: Float): N_LITERAL() {
     override fun toText() = "$value"
     override fun codeValue(coder: Coder) { coder.value(this, value) }
+    override fun constantValue() = VFloat(value)
 }
 
 class N_LITERAL_OBJ(val objID: ObjID): N_LITERAL() {
     override fun toText() = "#$id"
     override fun codeValue(coder: Coder) { coder.value(this, objID) }
+    override fun constantValue() = VObj(objID)
 }
 
 class N_LITERAL_STRING(val value: String): N_LITERAL() {
     override fun toText() = "\"$value\""
     override fun codeValue(coder: Coder) { coder.value(this, value) }
+    override fun constantValue() = VString(value)
 }
 
 class N_LITERAL_LIST(val value: List<N_EXPR>): N_LITERAL() {
     override fun kids() = value
     override fun toText() = value.joinToString(", ", "LIST[", "]")
+    override fun constantValue(): Value? {
+        val constant = mutableListOf<Value>()
+        value.forEach { expr ->
+            val exprConstant = expr.constantValue()
+            if (exprConstant == null) return null else constant.add(exprConstant)
+        }
+        return VList(constant)
+    }
     override fun code(coder: Coder) {
+        if (codeConstant(coder)) return
         value.forEach { it.code(coder) }
         coder.code(this, O_LISTVAL)
         coder.value(this, value.size)
@@ -54,7 +68,21 @@ class N_LITERAL_LIST(val value: List<N_EXPR>): N_LITERAL() {
 class N_LITERAL_MAP(val value: Map<N_EXPR, N_EXPR>): N_LITERAL() {
     override fun kids() = (value.keys + value.values).toList()
     override fun toText() = value.keys.joinToString(", ", "MAP[", "]") { "$it: ${value[it]}" }
+    override fun constantValue(): Value? {
+        val constant = mutableMapOf<Value, Value>()
+        value.keys.forEach { key ->
+            val keyConstant = key.constantValue()
+            if (keyConstant == null) return null else {
+                val valConstant = value[key]!!.constantValue()
+                if (valConstant == null) return null else {
+                    constant.set(keyConstant, valConstant)
+                }
+            }
+        }
+        return VMap(constant)
+    }
     override fun code(coder: Coder) {
+        if (codeConstant(coder)) return
         value.keys.forEach { key ->
             value[key]!!.code(coder)
             key.code(coder)

--- a/src/main/kotlin/value/VFloat.kt
+++ b/src/main/kotlin/value/VFloat.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.math.ceil
 import kotlin.math.floor
+import kotlin.math.pow
 
 @Serializable
 @SerialName("VFloat")
@@ -37,6 +38,11 @@ data class VFloat(val v: Float): Value() {
     override fun divide(a2: Value) = when (a2) {
         is VInt -> VFloat(v / a2.v.toFloat())
         is VFloat -> VFloat(v / a2.v)
+        else -> null
+    }
+    override fun toPower(a2: Value) = when (a2) {
+        is VInt -> VFloat(v.pow(a2.v))
+        is VFloat -> VFloat(v.pow(a2.v))
         else -> null
     }
 

--- a/src/main/kotlin/value/VInt.kt
+++ b/src/main/kotlin/value/VInt.kt
@@ -2,6 +2,7 @@ package com.dlfsystems.value
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlin.math.pow
 
 @Serializable
 @SerialName("VInt")
@@ -35,6 +36,15 @@ data class VInt(val v: Int): Value() {
     override fun divide(a2: Value) = when (a2) {
         is VInt -> VInt(v / a2.v)
         is VFloat -> VFloat(v.toFloat() / a2.v)
+        else -> null
+    }
+    override fun toPower(a2: Value) = when (a2) {
+        is VInt -> VInt(v.toDouble().pow(a2.v).toInt())
+        is VFloat -> VFloat(v.toFloat().pow(v))
+        else -> null
+    }
+    override fun modulo(a2: Value) = when (a2) {
+        is VInt -> VInt(v % a2.v)
         else -> null
     }
 

--- a/src/main/kotlin/value/Value.kt
+++ b/src/main/kotlin/value/Value.kt
@@ -48,6 +48,8 @@ sealed class Value {
     open fun plus(a2: Value): Value? = null
     open fun multiply(a2: Value): Value? = null
     open fun divide(a2: Value): Value? = null
+    open fun toPower(a2: Value): Value? = null
+    open fun modulo(a2: Value): Value? = null
 
     // Get or set a prop on this type.  Null raises E_PROPNF.
     open fun getProp(name: String): Value? = null

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -330,6 +330,16 @@ class VM(val verb: Verb) {
                     a1.divide(a2)?.also { push(it) }
                         ?: fail(E_TYPE, "cannot divide ${a1.type} and ${a2.type}")
                 }
+                O_POWER -> {
+                    val (a2, a1) = popTwo()
+                    a1.toPower(a2)?.also { push(it) }
+                        ?: fail(E_TYPE, "cannot raise ${a1.type} to power ${a2.type}")
+                }
+                O_MODULUS -> {
+                    val (a2, a1) = popTwo()
+                    a1.modulo(a2)?.also { push(it) }
+                        ?: fail(E_TYPE, "cannot modulo ${a1.type} by ${a2.type}")
+                }
 
                 else -> fail(E_SYS, "unknown opcode $word")
             }


### PR DESCRIPTION
It really bothered me reading compiler output to see so many instructions generated for constant expressions.  Originally I thought this was an edge case, but I realized that map/list construction could be optimized too.

When the compiler sees this:
```
fooList = ["foo", "bar", "baz"]
```
It naively generates O_VAL opcodes for each of the elements, then an O_LISTVAL to assemble a list.  It does this to allow for an expression generating any of the elements -- but it turns out they're just constants.

I decided to solve the general case.  To compile a N_EXPR, we call it.constantValue(), which recurses all its children to discover whether they're all constant.  If so, it returns the actual calculated value.  To make this happen we have to call N_EXPR.codeConstant() at the top of any N_EXPR.code() block which could be constant.

Along the way I noticed I forgot to implement 'power' and 'modulus' operators (even though we're parsing them!) so I did that too.

Code example:
```
foo = 24 * 7 * 365 + 100
bar = ["foo", "bar", "baz" + "X"]
```

Before:
```
<0> O_VAL 24
<2> O_VAL 7
<4> O_MULT
<5> O_VAL 365
<7> O_MULT
<8> O_VAL 100
<10> O_ADD
<11> O_SETVAR 0
<13> O_VAL "foo"
<15> O_VAL "bar"
<17> O_VAL "baz"
<19> O_VAL "X"
<21> O_ADD
<22> O_LISTVAL 3
<24> O_SETVAR 1
```

After:
```
<0> O_VAL 61420
<2> O_SETVAR 0
<4> O_VAL ["foo", "bar", "bazX"]
<6> O_SETVAR 1
```
