### PR TITLE
Copy opcodes to VFun

### DIFF
--- a/src/main/kotlin/compiler/Coder.kt
+++ b/src/main/kotlin/compiler/Coder.kt
@@ -170,6 +170,13 @@ class Coder(val ast: Node) {
                     value(args[0].value!!)
                 }
 
+                // O_VAL O_ADD => O_ADDVAL
+                ?: consume(O_VAL, null, O_ADD)?.also { args ->
+                    code(O_ADDVAL)
+                    value(args[0].value!!)
+                }
+
+
                 // If nothing matched, copy and continue
                 ?: run {
                     outMem.add(mem[pc++])

--- a/src/main/kotlin/compiler/Coder.kt
+++ b/src/main/kotlin/compiler/Coder.kt
@@ -16,7 +16,7 @@ class Coder(val ast: Node) {
     // Addresses stored to be used as future jump destinations.
     val backJumps = HashMap<String, Int>()
     // Entry points to literal VFuns.
-    val entryPoints = mutableListOf<Int>()
+    val blocks = mutableListOf<Pair<Int,Int>>()
 
     fun last() = if (mem.isEmpty()) null else mem[mem.size - 1]
 
@@ -44,10 +44,21 @@ class Coder(val ast: Node) {
     fun value(from: Node, listValue: List<Value>) { value(from, VList(listValue.toMutableList())) }
     fun value(from: Node, mapValue: Map<Value, Value>) { value(from, VMap(mapValue.toMutableMap())) }
 
-    // Record the entryPoint of a literal VFun.
-    fun codeEntryPoint(from: Node) {
-        value(from, entryPoints.size)
-        entryPoints.add(mem.size + 2) // +2 to skip the O_JUMP<addr> which will follow
+    // Record a block start address of a literal VFun.
+    // Code the block index (as arg for O_FUNVAL).
+    // Return the index to be passed later to blockEnd.
+    fun codeBlockStart(from: Node): Int {
+        val entryPoint = blocks.size
+        value(from, entryPoint)
+        blocks.add(Pair(mem.size + 2, -1))  // +2 to skip the O_JUMP<addr>
+        return entryPoint
+    }
+
+    // Record a block end address.  Assumes the start was already coded!
+    fun codeBlockEnd(from: Node, block: Int) {
+        blocks[block] = Pair(
+            blocks[block].first, mem.size
+        )
     }
 
     // Write a placeholder address for a jump we'll locate in the future.
@@ -95,7 +106,8 @@ class Coder(val ast: Node) {
         private val mem = coder.mem
         private val outMem = mutableListOf<VMWord>()
         private val jumpMap = mutableMapOf<Int, Int>()
-        private val entryMap = mutableListOf<Int>()
+        private val blockStartMap = mutableListOf<Int>()
+        private val blockEndMap = mutableListOf<Int>()
         private var pc = 0
         private var lastMatchSize = 0
 
@@ -107,15 +119,17 @@ class Coder(val ast: Node) {
                     jumpMap[address] = -1
                 }
             }
-            entryMap.addAll(coder.entryPoints)
+            blockStartMap.addAll(coder.blocks.map { it.first })
+            blockEndMap.addAll(coder.blocks.map { it.second })
 
             pc = 0
             while (pc < mem.size) {
                 // If we've reached a jump dest, record its new address
                 if (jumpMap.containsKey(pc)) jumpMap[pc] = outMem.size
                 // If we've reached an entry point, record its new address
-                if (coder.entryPoints.contains(pc)) {
-                    entryMap[coder.entryPoints.indexOf(pc)] = outMem.size
+                coder.blocks.forEachIndexed { n, it ->
+                    if (it.first == pc) blockStartMap[n] = outMem.size
+                    if (it.second == pc) blockEndMap[n] = outMem.size
                 }
 
                 // NEGATE NEGATE => ()
@@ -167,8 +181,9 @@ class Coder(val ast: Node) {
                     if (word.address == old) word.address = jumpMap[old]
                 }
             }
-            // Replace all entry points
-            coder.entryPoints.addAll(entryMap)
+            // Replace all block addresses
+            coder.blocks.clear()
+            coder.blocks.addAll(blockStartMap.mapIndexed { n, it -> Pair(it, blockEndMap[n])})
             // Replace compiled code
             coder.mem = outMem
         }

--- a/src/main/kotlin/compiler/Coder.kt
+++ b/src/main/kotlin/compiler/Coder.kt
@@ -107,8 +107,8 @@ class Coder(val ast: Node) {
         private val mem = coder.mem
         private val outMem = mutableListOf<VMWord>()
         private val jumpMap = mutableMapOf<Int, Int>()
-        private val blockStartMap = mutableListOf<Int>()
-        private val blockEndMap = mutableListOf<Int>()
+        private val blockStarts = mutableListOf<Int>()
+        private val blockEnds = mutableListOf<Int>()
         private var pc = 0
         private var lastMatchSize = 0
 
@@ -120,8 +120,8 @@ class Coder(val ast: Node) {
                     jumpMap[address] = -1
                 }
             }
-            blockStartMap.addAll(coder.blocks.map { it.start })
-            blockEndMap.addAll(coder.blocks.map { it.end })
+            blockStarts.addAll(coder.blocks.map { it.start })
+            blockEnds.addAll(coder.blocks.map { it.end })
 
             pc = 0
             while (pc < mem.size) {
@@ -129,8 +129,8 @@ class Coder(val ast: Node) {
                 if (jumpMap.containsKey(pc)) jumpMap[pc] = outMem.size
                 // If we've reached an entry point, record its new address
                 coder.blocks.forEachIndexed { n, it ->
-                    if (it.start == pc) blockStartMap[n] = outMem.size
-                    if (it.end == pc) blockEndMap[n] = outMem.size
+                    if (it.start == pc) blockStarts[n] = outMem.size
+                    if (it.end == pc) blockEnds[n] = outMem.size
                 }
 
                 // NEGATE NEGATE => ()
@@ -197,8 +197,8 @@ class Coder(val ast: Node) {
             }
             // Replace all block addresses
             coder.blocks.clear()
-            coder.blocks.addAll(blockStartMap.mapIndexed { n, it ->
-                Executable.Block(it, blockEndMap[n])
+            coder.blocks.addAll(blockStarts.mapIndexed { n, it ->
+                Executable.Block(it, blockEnds[n])
             })
             // Replace compiled code
             coder.mem = outMem

--- a/src/main/kotlin/compiler/Coder.kt
+++ b/src/main/kotlin/compiler/Coder.kt
@@ -170,6 +170,12 @@ class Coder(val ast: Node) {
                     value(args[0].value!!)
                 }
 
+                // O_ADD O_VAL O_ADD => O_CONCAT
+                ?: consume(O_ADD, O_VAL, null, O_ADD)?.also { args ->
+                    code(O_CONCAT)
+                    value(args[0].value!!)
+                }
+
                 // O_VAL O_ADD => O_ADDVAL
                 ?: consume(O_VAL, null, O_ADD)?.also { args ->
                     code(O_ADDVAL)

--- a/src/main/kotlin/compiler/Compiler.kt
+++ b/src/main/kotlin/compiler/Compiler.kt
@@ -13,7 +13,7 @@ object Compiler {
         val symbols: Map<String, Int>,
         val tokens: List<Token>,
         val ast: Node,
-        val entryPoints: List<Int>,
+        val blocks: List<Pair<Int,Int>>,
     )
 
     fun compile(source: String): Result {
@@ -21,7 +21,7 @@ object Compiler {
         var code: List<VMWord>? = null
         var ast: Node? = null
         var symbols: Map<String, Int>? = null
-        var entryPoints: List<Int>? = null
+        var blocks: List<Pair<Int,Int>>? = null
         try {
             // Stage 1: Lex source into tokens.
             tokens = Lexer(source).lex()
@@ -34,8 +34,8 @@ object Compiler {
             // Stage 4: Generate VM opcodes.
             val coder = Coder(ast).apply { generate() }
             code = coder.mem
-            entryPoints = coder.entryPoints
-            return Result(source, code, symbols, tokens, ast, entryPoints)
+            blocks = coder.blocks
+            return Result(source, code, symbols, tokens, ast, blocks)
         } catch (e: CompileException) {
             throw e.withInfo(code, symbols, tokens, ast)
         } catch (e: Exception) {

--- a/src/main/kotlin/compiler/Compiler.kt
+++ b/src/main/kotlin/compiler/Compiler.kt
@@ -13,7 +13,7 @@ object Compiler {
         val symbols: Map<String, Int>,
         val tokens: List<Token>,
         val ast: Node,
-        val blocks: List<Pair<Int,Int>>,
+        val blocks: List<Executable.Block>,
     )
 
     fun compile(source: String): Result {
@@ -21,7 +21,7 @@ object Compiler {
         var code: List<VMWord>? = null
         var ast: Node? = null
         var symbols: Map<String, Int>? = null
-        var blocks: List<Pair<Int,Int>>? = null
+        var blocks: List<Executable.Block>? = null
         try {
             // Stage 1: Lex source into tokens.
             tokens = Lexer(source).lex()

--- a/src/main/kotlin/compiler/Parser.kt
+++ b/src/main/kotlin/compiler/Parser.kt
@@ -431,28 +431,11 @@ class Parser(inputTokens: List<Token>) {
 
     // Parse: !|-<expr>
     private fun pInverse(): N_EXPR? {
-        val next = this::pIfElse
+        val next = this::pFuncall
         consume(T_BANG, T_MINUS)?.also { operator ->
             pExpression()?.also { right ->
                 return node(N_NEGATE(right))
             } ?: fail("expression expected after $operator")
-        }
-        return next()
-    }
-
-    // Parse (as expression): if <expr> <expr> else <expr>
-    private fun pIfElse(): N_EXPR? {
-        val next = this::pFuncall
-        consume(T_IF)?.also {
-            pExpression()?.also { condition ->
-                pExpression()?.also { eThen ->
-                    consume(T_ELSE)?.also {
-                        pExpression()?.also { eElse ->
-                            return node(N_CONDITIONAL(condition, eThen, eElse))
-                        } ?: fail("missing else expression")
-                    } ?: fail("expected else in if expression")
-                } ?: fail("missing expression")
-            } ?: fail("missing condition")
         }
         return next()
     }

--- a/src/main/kotlin/compiler/ast/N_EXPR.kt
+++ b/src/main/kotlin/compiler/ast/N_EXPR.kt
@@ -57,12 +57,12 @@ class N_STRING_SUB(val parts: List<N_EXPR>): N_EXPR() {
 
     override fun code(coder: Coder) {
         when (parts.size) {
-            0 -> N_LITERAL_STRING("").code(coder)
+            0 -> return
             else -> {
-                if (parts[0].toString() != "") parts[0].code(coder)
+                if (!parts[0].isEmptyString()) parts[0].code(coder)
                 var i = 1
                 while (i < parts.size) {
-                    if (parts[i].toString() != "") {
+                    if (!parts[i].isEmptyString()) {
                         parts[i].code(coder)
                         coder.code(this, O_ADD)
                     }
@@ -71,6 +71,8 @@ class N_STRING_SUB(val parts: List<N_EXPR>): N_EXPR() {
             }
         }
     }
+
+    private fun N_EXPR.isEmptyString() = (this is N_LITERAL_STRING) && (this.value == "")
 }
 
 // A three-part conditional expression: (cond) ? trueExpr : falseExpr

--- a/src/main/kotlin/compiler/ast/N_EXPR.kt
+++ b/src/main/kotlin/compiler/ast/N_EXPR.kt
@@ -59,10 +59,10 @@ class N_STRING_SUB(val parts: List<N_EXPR>): N_EXPR() {
         when (parts.size) {
             0 -> N_LITERAL_STRING("").code(coder)
             else -> {
-                parts[0].code(coder)
+                if (parts[0].toString() != "") parts[0].code(coder)
                 var i = 1
                 while (i < parts.size) {
-                    if (!(parts[i] is N_LITERAL_STRING && (parts[i] as N_LITERAL_STRING).value == "")) {
+                    if (parts[i].toString() != "") {
                         parts[i].code(coder)
                         coder.code(this, O_ADD)
                     }

--- a/src/main/kotlin/compiler/ast/N_LITERAL.kt
+++ b/src/main/kotlin/compiler/ast/N_LITERAL.kt
@@ -72,11 +72,12 @@ class N_LITERAL_FUN(val args: List<N_IDENTIFIER>, val block: N_BLOCK): N_LITERAL
         coder.code(this, O_VAL)
         coder.value(this, block.collectVars().map { VString(it) })
         coder.code(this, O_FUNVAL)
-        coder.codeEntryPoint(this)
+        val blockID = coder.codeBlockStart(this)
         coder.code(this, O_JUMP)
         coder.jumpForward(this, "skipFun")
         block.code(coder)
         coder.code(this, O_RETURN)
+        coder.codeBlockEnd(this, blockID)
         coder.setForwardJump(this, "skipFun")
     }
 }

--- a/src/main/kotlin/compiler/ast/N_STATEMENT.kt
+++ b/src/main/kotlin/compiler/ast/N_STATEMENT.kt
@@ -158,13 +158,7 @@ class N_EXPRSTATEMENT(val expr: N_EXPR): N_STATEMENT() {
 
     override fun code(coder: Coder) {
         expr.code(coder)
-        // Since this expression is in a statement context, discard its result to avoid stack pollution.
-        // TODO: Determine if there are actual circumstances this would matter.  I can't think of any --
-        // TODO: expressions can't have statements inside them, so stack integrity seems to only matter
-        // TODO: within an expression no matter how deep.  If we leave a value on the stack for every
-        // TODO: naked statement it only matters for heap use during execution.  I don't really care.
-        // TODO: Not doing this lets us pick the last exprstatement value off the stack for eval.
-        // coder.code(this, O_DISCARD)
+        coder.code(this, O_DISCARD)
     }
 }
 

--- a/src/main/kotlin/compiler/ast/Node.kt
+++ b/src/main/kotlin/compiler/ast/Node.kt
@@ -32,10 +32,10 @@ abstract class Node {
     open fun identify() { }
 
     // Collect all variable names under this node.
-    fun collectVars(): List<String> = buildList {
+    fun collectVars(): List<String> = buildSet {
         kids().forEach { addAll(it.collectVars()) }
         variableName()?.also { add(it) }
-    }
+    }.toList()
 
     // Return our name if we're an identifier for a variable.
     open fun variableName(): String? = null

--- a/src/main/kotlin/value/VFun.kt
+++ b/src/main/kotlin/value/VFun.kt
@@ -1,9 +1,11 @@
 package com.dlfsystems.value
 
+import com.dlfsystems.server.Yegg
 import com.dlfsystems.vm.Context
 import com.dlfsystems.vm.VMException.Type.E_RANGE
 import com.dlfsystems.vm.VMWord
 import com.dlfsystems.vm.Executable
+import com.dlfsystems.vm.VM
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -23,10 +25,9 @@ data class VFun(
     override fun toString() = "VFUN"
     override fun asString() = toString()
 
-    override val code = buildList { addAll(withCode) }
+    override val code = withCode // no need to copy, it was made on demand
     override val symbols = buildMap { withSymbols.forEach { put(it.key, it.value) } }
     override val blocks = buildList { addAll(withBlocks) }
-    override var jumpOffset = 0
 
     override fun callVerb(c: Context, name: String, args: List<Value>): Value? {
         when (name) {
@@ -36,17 +37,19 @@ data class VFun(
     }
 
     fun verbInvoke(c: Context, args: List<Value>): Value {
-            if ((args.size < argNames.size) || (args.size > argNames.size && args.size > 1))
-                fail(E_RANGE, "lambda wants ${argNames.size} args but got ${args.size}")
-
-            return verb.call(c, vThis, listOf(), entryPoint, withVars = buildMap {
-                vars.forEach { (name, v) -> put(name, v) }
-                argNames.forEachIndexed { n, name ->
-                    args.getOrNull(n)?.also { put(name, it) } ?: fail(E_RANGE, "arg $name not found")
-                }
-                if (argNames.isEmpty() && args.size == 1) put("it", args[0])
-            })
-
+        if ((args.size < argNames.size) || (args.size > argNames.size && args.size > 1))
+            fail(E_RANGE, "lambda wants ${argNames.size} args but got ${args.size}")
+        val vm = VM(this)
+        c.push(c.vThis, Yegg.vNullTrait, "->", args, vm)
+        val r = vm.execute(c, listOf(), buildMap {
+            vars.forEach { (name, v) -> put(name, v) }
+            argNames.forEachIndexed { n, name ->
+                args.getOrNull(n)?.also { put(name, it) } ?: fail(E_RANGE, "arg $name not found")
+            }
+            if (argNames.isEmpty() && args.size == 1) put("it", args[0])
+        })
+        c.pop()
+        return r
     }
 
 }

--- a/src/main/kotlin/value/VFun.kt
+++ b/src/main/kotlin/value/VFun.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.Serializable
 data class VFun(
     val withCode: List<VMWord>,
     val withSymbols: Map<String, Int>,
-    val withBlocks: List<Pair<Int, Int>>,
+    val withBlocks: List<Executable.Block>,
     val vThis: VObj,
     val argNames: List<String>,
     val vars: Map<String, Value>,

--- a/src/main/kotlin/vm/Executable.kt
+++ b/src/main/kotlin/vm/Executable.kt
@@ -1,0 +1,16 @@
+package com.dlfsystems.vm
+
+interface Executable {
+
+    val code: List<VMWord>
+    val symbols: Map<String, Int>
+    val blocks: List<Pair<Int, Int>>
+    var jumpOffset: Int
+
+    fun getBlockCode(block: Int): List<VMWord> =
+        code.subList(blocks[block].first, blocks[block].second)  // SHIT!
+    // TODO: this needs to remap addresses!
+    // TODO: start is offset, subtract from all address args
+    // alternate plan: just pass the offset  to VM and have it apply it to all addresses/jumps?!?!
+
+}

--- a/src/main/kotlin/vm/Executable.kt
+++ b/src/main/kotlin/vm/Executable.kt
@@ -3,12 +3,16 @@ package com.dlfsystems.vm
 import com.dlfsystems.value.VFun
 import com.dlfsystems.value.VObj
 import com.dlfsystems.value.Value
+import kotlinx.serialization.Serializable
 
 interface Executable {
 
+    @Serializable
+    data class Block(val start: Int, val end: Int)
+
     val code: List<VMWord>
     val symbols: Map<String, Int>
-    val blocks: List<Pair<Int, Int>>
+    val blocks: List<Block>
 
     fun getLambda(
         block: Int,
@@ -16,8 +20,8 @@ interface Executable {
         args: List<String>,
         withVars: Map<String, Value>,
     ): VFun {
-        val offset = blocks[block].first
-        val code = code.subList(blocks[block].first, blocks[block].second).map { word ->
+        val offset = blocks[block].start
+        val code = code.subList(blocks[block].start, blocks[block].end).map { word ->
             // Rewrite jump dests with offset
             word.address?.let { VMWord(
                 lineNum = word.lineNum,

--- a/src/main/kotlin/vm/Executable.kt
+++ b/src/main/kotlin/vm/Executable.kt
@@ -21,7 +21,7 @@ interface Executable {
         withVars: Map<String, Value>,
     ): VFun {
         val offset = blocks[block].start
-        val code = code.subList(blocks[block].start, blocks[block].end).map { word ->
+        val lambdaCode = code.subList(blocks[block].start, blocks[block].end).map { word ->
             // Rewrite jump dests with offset
             word.address?.let { VMWord(
                 lineNum = word.lineNum,
@@ -29,7 +29,7 @@ interface Executable {
                 address = it - offset
             ) } ?: word
         }
-        return VFun(code, symbols, blocks, vThis, args, withVars)
+        return VFun(lambdaCode, symbols, blocks, vThis, args, withVars)
     }
 
 }

--- a/src/main/kotlin/vm/Opcode.kt
+++ b/src/main/kotlin/vm/Opcode.kt
@@ -123,4 +123,7 @@ enum class Opcode(val argCount: Int = 0) {
     O_CMP_LTZ,
     O_CMP_LEZ,
 
+    // Push the addition of pop0 and value arg1.
+    O_ADDVAL(1),
+
 }

--- a/src/main/kotlin/vm/Opcode.kt
+++ b/src/main/kotlin/vm/Opcode.kt
@@ -126,4 +126,7 @@ enum class Opcode(val argCount: Int = 0) {
     // Push the addition of pop0 and value arg1.
     O_ADDVAL(1),
 
+    // Push the addition of pop0, pop1, and value arg1.
+    O_CONCAT(1),
+
 }

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -317,6 +317,12 @@ class VM(val exe: Executable) {
                     a1.plus(a2)?.also { push(it) }
                         ?: fail(E_TYPE, "cannot add ${a1.type} and ${a2.type}")
                 }
+                O_ADDVAL -> {
+                    val a1 = pop()
+                    val a2 = next().value!!
+                    a1.plus(a2)?.also { push(it) }
+                        ?: fail(E_TYPE, "cannot add ${a1.type} and ${a2.type}")
+                }
                 O_MULT -> {
                     val (a2, a1) = popTwo()
                     a1.multiply(a2)?.also { push(it) }

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -99,7 +99,6 @@ class VM(val exe: Executable) {
                 }
                 O_FUNVAL -> {
                     val block = next().intFromV
-                    val code = exe.getBlockCode(block) // TODO: get jump offset?
                     // Capture variables from scope
                     val withVars = buildMap {
                         (pop() as VList).v.map { (it as VString).v }.forEach { varName ->
@@ -109,7 +108,7 @@ class VM(val exe: Executable) {
                         }
                     }
                     val args = (pop() as VList).v.map { (it as VString).v }
-                    push(VFun(code, exe.symbols, exe.blocks, c.vThis, args, withVars))
+                    push(exe.getLambda(block, c.vThis, args, withVars))
                 }
 
                 // Index/range ops

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -192,15 +192,17 @@ class VM(val exe: Executable) {
                     val args = mutableListOf<Value>()
                     repeat (argCount) { args.add(0, pop()) }
                     exe.symbols[name]?.also { variableID ->
+                        var result: Value? = null
                         // Look for variable with VFun
                         variables[variableID]?.let { subject ->
                             if (subject is VFun) {
-                                push(subject.verbInvoke(c, args))
+                                result = subject.verbInvoke(c, args)
                             } else fail(E_TYPE, "cannot invoke ${subject.type} as fun")
                         // Look for $sys.verb
                         } ?: Yegg.world.sys.callVerb(c, name, args)?.also {
-                            push(it)
+                            result = it
                         } ?: fail(E_VARNF, "no such fun or variable")
+                        result?.also { push(it) }
                     }
                 }
 

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -18,6 +18,8 @@ class VM(val exe: Executable) {
     private var pc: Int = 0
     // The local stack.
     private val stack = ArrayDeque<Value>()
+    private fun dumpStack() = stack.joinToString(",") { "$it" }
+
     // Local variables by ID.
     private val variables: MutableMap<Int, Value> = mutableMapOf()
 
@@ -150,11 +152,11 @@ class VM(val exe: Executable) {
                 }
                 O_RETURN -> {
                     if (stack.isEmpty()) fail(E_SYS, "no return value on stack!")
-                    if (stack.size > 1) fail(E_SYS, "stack polluted on return!")
+                    if (stack.size > 1) fail(E_SYS, "stack polluted on return!  ${dumpStack()}")
                     return pop()
                 }
                 O_RETURNNULL -> {
-                    if (stack.isNotEmpty()) fail(E_SYS, "stack polluted on return!")
+                    if (stack.isNotEmpty()) fail(E_SYS, "stack polluted on returnnull!  ${dumpStack()}")
                     return VVoid
                 }
                 O_RETVAL -> {
@@ -194,7 +196,7 @@ class VM(val exe: Executable) {
                         variables[variableID]?.let { subject ->
                             if (subject is VFun) {
                                 push(subject.verbInvoke(c, args))
-                            } else fail(E_TYPE, "cannot invoke ${subject?.type} as fun")
+                            } else fail(E_TYPE, "cannot invoke ${subject.type} as fun")
                         // Look for $sys.verb
                         } ?: Yegg.world.sys.callVerb(c, name, args)?.also {
                             push(it)

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -323,6 +323,14 @@ class VM(val exe: Executable) {
                     a1.plus(a2)?.also { push(it) }
                         ?: fail(E_TYPE, "cannot add ${a1.type} and ${a2.type}")
                 }
+                O_CONCAT -> {
+                    val (a2, a1) = popTwo()
+                    val a3 = next().value!!
+                    a1.plus(a2)?.also { a12 ->
+                        a12.plus(a3)?.also { push(it) }
+                            ?: fail(E_TYPE, "cannot add ${a12.type} and ${a3.type}")
+                    } ?: fail(E_TYPE, "cannot add ${a1.type} and ${a2.type}")
+                }
                 O_MULT -> {
                     val (a2, a1) = popTwo()
                     a1.multiply(a2)?.also { push(it) }

--- a/src/main/kotlin/world/trait/Verb.kt
+++ b/src/main/kotlin/world/trait/Verb.kt
@@ -9,6 +9,7 @@ import com.dlfsystems.vm.Context
 import com.dlfsystems.vm.VM
 import com.dlfsystems.vm.VMWord
 import com.dlfsystems.vm.dumpText
+import com.dlfsystems.vm.Executable
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 
@@ -16,11 +17,11 @@ import kotlinx.serialization.Transient
 class Verb(
     val name: String,
     val traitID: TraitID,
-) {
+): Executable {
     var source = ""
-    @Transient var code: List<VMWord> = listOf()
-    @Transient var symbols: Map<String, Int> = mapOf()
-    @Transient var entryPoints: List<Int> = listOf()
+    @Transient override var code: List<VMWord> = listOf()
+    @Transient override var symbols: Map<String, Int> = mapOf()
+    @Transient override var blocks: List<Pair<Int,Int>> = listOf()
 
     fun program(source: String) {
         this.source = source
@@ -30,13 +31,13 @@ class Verb(
 
     fun call(
         c: Context, vThis: VObj,
-        args: List<Value>, entryPoint: Int? = null,
+        args: List<Value>,
         withVars: Map<String, Value>? = null
     ): Value {
         if (code.isEmpty()) recompile()
         val vm = VM(this)
         c.push(vThis, Yegg.world.getTrait(traitID)!!.vTrait, name, args, vm)
-        val r = vm.execute(c, args, entryPoint, withVars)
+        val r = vm.execute(c, args, withVars)
         c.pop()
         return r
     }
@@ -45,7 +46,7 @@ class Verb(
         Compiler.compile(source).also {
             code = it.code
             symbols = it.symbols
-            entryPoints = it.entryPoints
+            blocks = it.blocks
         }
     }
 

--- a/src/main/kotlin/world/trait/Verb.kt
+++ b/src/main/kotlin/world/trait/Verb.kt
@@ -21,7 +21,7 @@ class Verb(
     var source = ""
     @Transient override var code: List<VMWord> = listOf()
     @Transient override var symbols: Map<String, Int> = mapOf()
-    @Transient override var blocks: List<Pair<Int,Int>> = listOf()
+    @Transient override var blocks: List<Executable.Block> = listOf()
 
     fun program(source: String) {
         this.source = source


### PR DESCRIPTION
VFun in master is simply a pointer to an entryPoint index in the declaring Verb's opcodes.  This causes wacky time travel bugs, when a lambda runs unexpected code in the future after a recompile.

This PR changes VFun to copy out its opcodes from the declaring Verb when pushed onto the stack at runtime.

In Coder/Compiler, N_LITERAL_FUN records both start and end of lambda blocks.  Optimizer is updated to respect these blocks when rewriting.

VFun and Verb both implement the Executable interface, and VFun is now made with code/symbols/blocks data derived from the declaring Verb.  Executable.getLambda() does the actual code surgery of copying out the opcodes and rewriting their jump addresses.

UNRELATED CHANGE:

Added O_ADDVAL and O_CONCAT opcodes to optimize common patterns in string sub code.
