### PR TITLE
Scheduling and fork

### DIFF
--- a/src/main/kotlin/compiler/Coder.kt
+++ b/src/main/kotlin/compiler/Coder.kt
@@ -1,6 +1,7 @@
 package com.dlfsystems.compiler
 
 import com.dlfsystems.compiler.ast.Node
+import com.dlfsystems.server.Yegg
 import com.dlfsystems.vm.Opcode
 import com.dlfsystems.vm.Opcode.*
 import com.dlfsystems.vm.VMWord
@@ -25,7 +26,7 @@ class Coder(val ast: Node) {
     // Nodes will then call Coder.code() and Coder.value() to output their compiled code.
     fun generate() {
         ast.code(this)
-        Optimizer(this).optimize()
+        if (Yegg.optimizeCompiler) Optimizer(this).optimize()
     }
 
     // Write an opcode into memory.

--- a/src/main/kotlin/compiler/Coder.kt
+++ b/src/main/kotlin/compiler/Coder.kt
@@ -182,6 +182,13 @@ class Coder(val ast: Node) {
                     value(args[0].value!!)
                 }
 
+                // O_FUNCALL O_DISCARD => O_FUNVOKE
+                ?: consume(O_FUNCALL, null, null, O_DISCARD)?.also { args ->
+                    code(O_FUNVOKE)
+                    value(args[0].value!!)
+                    value(args[1].value!!)
+                }
+
 
                 // If nothing matched, copy and continue
                 ?: run {

--- a/src/main/kotlin/compiler/Lexer.kt
+++ b/src/main/kotlin/compiler/Lexer.kt
@@ -183,7 +183,7 @@ class Lexer(val source: String) {
     private fun isIdentifierChar(c: Char) = (c in 'a'..'z') || (c in 'A'..'Z') || (c in '0'..'9') || (c == '_')
 
     // Is this a legal char for an internal ID string?
-    private fun isIDChar(c: Char) = Yegg.idChars.contains(c)
+    private fun isIDChar(c: Char) = Yegg.ID_CHARS.contains(c)
 
     // Begin a new accumulating token of (possibly) type.  Start with acc if given.
     private fun begin(type: TokenType, acc: Char? = null) {

--- a/src/main/kotlin/compiler/Parser.kt
+++ b/src/main/kotlin/compiler/Parser.kt
@@ -74,6 +74,8 @@ class Parser(inputTokens: List<Token>) {
         pWhileLoop()?.also { return it }
         pReturn()?.also { return it }
         pFail()?.also { return it }
+        pSuspend()?.also { return it }
+        pFork()?.also { return it }
         pWhen(asStatement = true)?.also { return node(N_EXPRSTATEMENT(it)) }
         pIncrement()?.also { return it }
         pDestructureList()?.also { return it }
@@ -189,6 +191,27 @@ class Parser(inputTokens: List<Token>) {
         consume(T_FAIL) ?: return null
         pExpression()?.also { return node(N_FAIL(it)) }
             ?: fail("missing message expression for fail")
+        return null
+    }
+
+    // Parse: suspend <expr>
+    private fun pSuspend(): N_STATEMENT? {
+        consume(T_SUSPEND) ?: return null
+        pExpression()?.also { return node(N_SUSPEND(it)) }
+            ?: fail("missing time expression for suspend")
+        return null
+    }
+
+    // Parse: fork <expr> { block }
+    private fun pFork(): N_STATEMENT? {
+        consume(T_FORK) ?: return null
+        pExpression()?.also { seconds ->
+            pBlock()?.also { block ->
+                return node(N_FORK(
+                    seconds,
+                    node(N_LITERAL_FUN(listOf(), block))
+                )) } ?: fail("missing block for fork")
+        } ?: fail("missing time expression for fork")
         return null
     }
 

--- a/src/main/kotlin/compiler/Token.kt
+++ b/src/main/kotlin/compiler/Token.kt
@@ -66,6 +66,8 @@ enum class TokenType(val literal: String, val isKeyword: Boolean = false) {
     T_WHILE("while", true),
     T_FAIL("fail", true),
     T_WHEN("when", true),
+    T_SUSPEND("suspend", true),
+    T_FORK("fork", true),
 
     T_EOF("EOF");
 }

--- a/src/main/kotlin/compiler/ast/N_EXPR.kt
+++ b/src/main/kotlin/compiler/ast/N_EXPR.kt
@@ -59,7 +59,7 @@ class N_STRING_SUB(val parts: List<N_EXPR>): N_EXPR() {
         when (parts.size) {
             0 -> return
             else -> {
-                if (!parts[0].isEmptyString()) parts[0].code(coder)
+                parts[0].code(coder)
                 var i = 1
                 while (i < parts.size) {
                     if (!parts[i].isEmptyString()) {

--- a/src/main/kotlin/compiler/ast/N_LITERAL.kt
+++ b/src/main/kotlin/compiler/ast/N_LITERAL.kt
@@ -92,7 +92,7 @@ class N_LITERAL_MAP(val value: Map<N_EXPR, N_EXPR>): N_LITERAL() {
     }
 }
 
-class N_LITERAL_FUN(val args: List<N_IDENTIFIER>, val block: N_BLOCK): N_LITERAL() {
+class N_LITERAL_FUN(val args: List<N_IDENTIFIER>, val block: N_STATEMENT): N_LITERAL() {
     override fun kids() = args + listOf(block)
     override fun code(coder: Coder) {
         coder.code(this, O_VAL)

--- a/src/main/kotlin/compiler/ast/N_STATEMENT.kt
+++ b/src/main/kotlin/compiler/ast/N_STATEMENT.kt
@@ -197,3 +197,24 @@ class N_INCREMENT(val identifier: N_IDENTIFIER, val isDecrement: Boolean = false
         coder.value(this, identifier.variableID!!)
     }
 }
+
+class N_SUSPEND(val seconds: N_EXPR): N_STATEMENT() {
+    override fun toText() = "suspend ($seconds)"
+    override fun kids() = listOf(seconds)
+
+    override fun code(coder: Coder) {
+        seconds.code(coder)
+        coder.code(this, O_SUSPEND)
+    }
+}
+
+class N_FORK(val seconds: N_EXPR, val function: N_LITERAL_FUN): N_STATEMENT() {
+    override fun toText() = "fork ($seconds) $function"
+    override fun kids() = listOf(seconds, function)
+
+    override fun code(coder: Coder) {
+        seconds.code(coder)
+        function.code(coder)
+        coder.code(this, O_FORK)
+    }
+}

--- a/src/main/kotlin/server/Connection.kt
+++ b/src/main/kotlin/server/Connection.kt
@@ -95,12 +95,7 @@ class Connection(private val sendText: (String) -> Unit) {
             vThis = match.obj?.vThis ?: Yegg.vNullObj
             vUser = connection?.user?.vThis ?: Yegg.vNullObj
         }
-        try {
-            match.trait.callVerb(c, match.verb, match.args)
-        } catch (e: Exception) {
-            sendText(e.toString())
-            sendText(c.stackDump())
-        }
+        MCP.schedule(c, match.trait.id, match.verb, match.args)
     }
 
     // Respond to meta commands.

--- a/src/main/kotlin/server/Connection.kt
+++ b/src/main/kotlin/server/Connection.kt
@@ -95,7 +95,12 @@ class Connection(private val sendText: (String) -> Unit) {
             vThis = match.obj?.vThis ?: Yegg.vNullObj
             vUser = connection?.user?.vThis ?: Yegg.vNullObj
         }
-        MCP.schedule(c, match.trait.id, match.verb, match.args)
+        Yegg.world.getTrait(match.trait.id)?.verbs?.get(match.verb)?.also { verb ->
+            MCP.schedule(c, verb, match.args)
+        } ?: run {
+            sendText("ERR: No verb ${match.verb} found for command")
+            sendText(c.stackDump())
+        }
     }
 
     // Respond to meta commands.

--- a/src/main/kotlin/server/Connection.kt
+++ b/src/main/kotlin/server/Connection.kt
@@ -30,7 +30,7 @@ class Connection(private val sendText: (String) -> Unit) {
         } ?: run {
             if (text.startsWith(";")) {
                 val code = text.substringAfter(";")
-                sendText(Compiler.eval(Context(this), code))
+                sendText(Compiler.eval(Context(this), "return $code"))
             } else if (text.startsWith("@")) {
                 // TODO: get rid of these hardcoded @meta commands
                 parseMeta(text)

--- a/src/main/kotlin/server/MCP.kt
+++ b/src/main/kotlin/server/MCP.kt
@@ -1,0 +1,69 @@
+package com.dlfsystems.server
+
+import com.dlfsystems.vm.Context
+import com.dlfsystems.util.systemEpoch
+import com.dlfsystems.value.VFun
+import com.dlfsystems.value.Value
+import com.dlfsystems.world.trait.TraitID
+import kotlinx.coroutines.delay
+
+
+object MCP {
+
+    private val taskMap = mutableMapOf<TaskID, Task>()
+    private val timeMap = mutableMapOf<Int, MutableList<TaskID>>()
+
+
+    fun schedule(vFun: VFun, seconds: Int = 0) {
+
+    }
+
+    fun schedule(c: Context, trait: TraitID, verb: String, args: List<Value>, seconds: Int = 0) {
+        schedule(Task(systemEpoch() + seconds, c, trait, verb, args))
+    }
+
+    fun schedule(task: Task) {
+        taskMap[task.id] = task
+        timeMap[task.atSeconds]?.add(task.id) ?: run {
+            timeMap[task.atSeconds] = mutableListOf(task.id)
+        }
+    }
+
+    suspend fun runTasks() {
+        while (true) {
+            getNextTask()?.also { task ->
+                taskMap.remove(task.id)
+                timeMap[task.atSeconds]!!.apply {
+                    remove(task.id)
+                    if (isEmpty()) timeMap.remove(task.atSeconds)
+                }
+                runTask(task)
+            } ?: run {
+                delay(100L)
+            }
+        }
+    }
+
+    private fun getNextTask(): Task? {
+        if (timeMap.isEmpty()) return null
+        // Find lowest time we have tasks for
+        var exeTime = timeMap.keys.first()
+        timeMap.keys.forEach { if (it < exeTime) exeTime = it }
+        // If that's in the future, abort
+        if (exeTime > systemEpoch()) return null
+        // Return the first task in the current second
+        return timeMap[exeTime]!!.let { taskMap[it.first()] }
+    }
+
+    private fun runTask(task: Task) {
+        try {
+            Yegg.world.getTrait(task.trait)!!.callVerb(task.c, task.verb, task.args)
+        } catch (e: SuspendException) {
+            // TODO: how tf is this gonna work
+            schedule(task.apply { atSeconds = systemEpoch() + e.seconds })
+        } catch (e: Exception) {
+            task.c.connection?.sendText(e.toString())
+            task.c.connection?.sendText(task.c.stackDump())
+        }
+    }
+}

--- a/src/main/kotlin/server/MCP.kt
+++ b/src/main/kotlin/server/MCP.kt
@@ -52,7 +52,7 @@ object MCP {
             // TODO: how tf is this gonna work
             // TODO: the resumed task will assume it can return values back through the stack, but those calls no longer exist
             // TODO: reevaluate calling/returning through callstack
-            schedule(task.apply { atEpoch = systemEpoch() + e.seconds })
+            // schedule(task.apply { atEpoch = systemEpoch() + e.seconds })
         } catch (e: Exception) {
             task.c.connection?.sendText(e.toString())
             task.c.connection?.sendText(task.c.stackDump())

--- a/src/main/kotlin/server/SuspendException.kt
+++ b/src/main/kotlin/server/SuspendException.kt
@@ -1,5 +1,0 @@
-package com.dlfsystems.server
-
-class SuspendException(val seconds: Int): Exception() {
-
-}

--- a/src/main/kotlin/server/SuspendException.kt
+++ b/src/main/kotlin/server/SuspendException.kt
@@ -1,0 +1,5 @@
+package com.dlfsystems.server
+
+class SuspendException(val seconds: Int): Exception() {
+
+}

--- a/src/main/kotlin/server/Task.kt
+++ b/src/main/kotlin/server/Task.kt
@@ -1,0 +1,18 @@
+package com.dlfsystems.server
+
+import com.dlfsystems.value.Value
+import com.dlfsystems.vm.Context
+import com.dlfsystems.world.trait.TraitID
+
+
+data class TaskID(val id: String) { override fun toString() = id }
+
+data class Task(
+    var atSeconds: Int,
+    val c: Context,
+    val trait: TraitID,
+    val verb: String,
+    val args: List<Value>,
+) {
+    val id = TaskID(Yegg.newID())
+}

--- a/src/main/kotlin/server/Task.kt
+++ b/src/main/kotlin/server/Task.kt
@@ -1,17 +1,22 @@
 package com.dlfsystems.server
 
+import com.dlfsystems.util.TaskIDGenerator
 import com.dlfsystems.value.Value
 import com.dlfsystems.vm.Context
 import com.dlfsystems.vm.Executable
+import java.lang.Comparable
 
 
-data class TaskID(val id: String) { override fun toString() = id }
+data class TaskID(val id: String): Comparable<TaskID> {
+    override fun toString() = id
+    override fun compareTo(other: TaskID) = id.compareTo(other.id)
+}
 
 data class Task(
-    var atSeconds: Int,
+    var atEpoch: Int,
     val c: Context,
     val exe: Executable,
     val args: List<Value>,
 ) {
-    val id = TaskID(Yegg.newID())
+    val id = TaskID(TaskIDGenerator.generate(atEpoch * 1000L))
 }

--- a/src/main/kotlin/server/Task.kt
+++ b/src/main/kotlin/server/Task.kt
@@ -2,7 +2,7 @@ package com.dlfsystems.server
 
 import com.dlfsystems.value.Value
 import com.dlfsystems.vm.Context
-import com.dlfsystems.world.trait.TraitID
+import com.dlfsystems.vm.Executable
 
 
 data class TaskID(val id: String) { override fun toString() = id }
@@ -10,8 +10,7 @@ data class TaskID(val id: String) { override fun toString() = id }
 data class Task(
     var atSeconds: Int,
     val c: Context,
-    val trait: TraitID,
-    val verb: String,
+    val exe: Executable,
     val args: List<Value>,
 ) {
     val id = TaskID(Yegg.newID())

--- a/src/main/kotlin/server/Yegg.kt
+++ b/src/main/kotlin/server/Yegg.kt
@@ -14,6 +14,8 @@ object Yegg {
 
     var worldName = "Minimal"
     var logLevel = Log.Level.DEBUG
+    var optimizeCompiler = true
+
     private val JSON = Json { allowStructuredMapKeys = true }
 
     private const val CONNECT_MSG = "** Connected **"

--- a/src/main/kotlin/server/Yegg.kt
+++ b/src/main/kotlin/server/Yegg.kt
@@ -5,9 +5,7 @@ import com.dlfsystems.value.*
 import com.dlfsystems.world.World
 import com.dlfsystems.world.Obj
 import io.viascom.nanoid.NanoId
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 import kotlinx.serialization.json.Json
 import java.io.File
 import kotlin.system.exitProcess
@@ -34,9 +32,12 @@ object Yegg {
     private val connections = mutableSetOf<Connection>()
     val connectedUsers = mutableMapOf<Obj, Connection>()
 
+    var schedulerJob: Job? = null
+
     val idChars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
     fun newID() = NanoId.generateOptimized(8, idChars, 61, 16)
 
+    @OptIn(DelicateCoroutinesApi::class)
     fun start() {
         val file = File("$worldName.yegg")
         if (file.exists()) {
@@ -64,7 +65,7 @@ object Yegg {
             }
         }
 
-        GlobalScope.launch {
+        schedulerJob = GlobalScope.launch {
             MCP.runTasks()
         }
     }

--- a/src/main/kotlin/server/Yegg.kt
+++ b/src/main/kotlin/server/Yegg.kt
@@ -5,7 +5,6 @@ import com.dlfsystems.value.*
 import com.dlfsystems.world.World
 import com.dlfsystems.world.Obj
 import io.viascom.nanoid.NanoId
-import kotlinx.coroutines.*
 import kotlinx.serialization.json.Json
 import java.io.File
 import kotlin.system.exitProcess
@@ -34,13 +33,16 @@ object Yegg {
     private val connections = mutableSetOf<Connection>()
     val connectedUsers = mutableMapOf<Obj, Connection>()
 
-    var schedulerJob: Job? = null
+    const val ID_CHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    fun newID() = NanoId.generateOptimized(8, ID_CHARS, 61, 16)
 
-    val idChars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    fun newID() = NanoId.generateOptimized(8, idChars, 61, 16)
-
-    @OptIn(DelicateCoroutinesApi::class)
+    // Start the server.
     fun start() {
+        loadWorld()
+        MCP.start()
+    }
+
+    private fun loadWorld() {
         val file = File("$worldName.yegg")
         if (file.exists()) {
             Log.i("Loading database from ${file.path}...")
@@ -65,10 +67,6 @@ object Yegg {
                     props["password"] = VString("")
                 }
             }
-        }
-
-        schedulerJob = GlobalScope.launch {
-            MCP.runTasks()
         }
     }
 

--- a/src/main/kotlin/server/Yegg.kt
+++ b/src/main/kotlin/server/Yegg.kt
@@ -5,6 +5,9 @@ import com.dlfsystems.value.*
 import com.dlfsystems.world.World
 import com.dlfsystems.world.Obj
 import io.viascom.nanoid.NanoId
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import java.io.File
 import kotlin.system.exitProcess
@@ -59,6 +62,10 @@ object Yegg {
                     props["password"] = VString("")
                 }
             }
+        }
+
+        GlobalScope.launch {
+            MCP.runTasks()
         }
     }
 

--- a/src/main/kotlin/util/TaskIDGenerator.kt
+++ b/src/main/kotlin/util/TaskIDGenerator.kt
@@ -1,0 +1,60 @@
+package com.dlfsystems.util
+
+import kotlin.experimental.and
+import kotlin.random.Random
+
+object TaskIDGenerator {
+    private const val ID_LENGTH = 26
+    private const val ENTROPY_SIZE = 4
+
+    // Base32 characters mapping
+    private val charMapping = charArrayOf(
+        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k',
+        'm', 'n', 'p', 'q', 'r', 's', 't', 'v', 'w', 'x',
+        'y', 'z'
+    )
+
+    // Generate task ID string for a given queue time.
+    // Unique and lexically sortable by creation time.
+    fun generate(time: Long) = generate(time, System.currentTimeMillis(), Random.nextBytes(ENTROPY_SIZE))
+
+    private fun generate(time: Long, createTime: Long, entropy: ByteArray): String {
+
+        val chars = CharArray(ID_LENGTH)
+
+        // time
+        chars[0] = charMapping[time.ushr(45).toInt() and 0x1f]
+        chars[1] = charMapping[time.ushr(40).toInt() and 0x1f]
+        chars[2] = charMapping[time.ushr(35).toInt() and 0x1f]
+        chars[3] = charMapping[time.ushr(30).toInt() and 0x1f]
+        chars[4] = charMapping[time.ushr(25).toInt() and 0x1f]
+        chars[5] = charMapping[time.ushr(20).toInt() and 0x1f]
+        chars[6] = charMapping[time.ushr(15).toInt() and 0x1f]
+        chars[7] = charMapping[time.ushr(10).toInt() and 0x1f]
+        chars[8] = charMapping[time.ushr(5).toInt() and 0x1f]
+        chars[9] = charMapping[time.toInt() and 0x1f]
+
+        // createTime
+        chars[10] = charMapping[createTime.ushr(45).toInt() and 0x1f]
+        chars[11] = charMapping[createTime.ushr(40).toInt() and 0x1f]
+        chars[12] = charMapping[createTime.ushr(35).toInt() and 0x1f]
+        chars[13] = charMapping[createTime.ushr(30).toInt() and 0x1f]
+        chars[14] = charMapping[createTime.ushr(25).toInt() and 0x1f]
+        chars[15] = charMapping[createTime.ushr(20).toInt() and 0x1f]
+        chars[16] = charMapping[createTime.ushr(15).toInt() and 0x1f]
+        chars[17] = charMapping[createTime.ushr(10).toInt() and 0x1f]
+        chars[18] = charMapping[createTime.ushr(5).toInt() and 0x1f]
+        chars[19] = charMapping[createTime.toInt() and 0x1f]
+
+        // entropy
+        chars[20] = charMapping[(entropy[0].toShort() and 0xff).toInt().ushr(3)]
+        chars[21] = charMapping[(entropy[0].toInt() shl 2 or (entropy[1].toShort() and 0xff).toInt().ushr(6) and 0x1f)]
+        chars[22] = charMapping[((entropy[1].toShort() and 0xff).toInt().ushr(1) and 0x1f)]
+        chars[23] = charMapping[(entropy[1].toInt() shl 4 or (entropy[2].toShort() and 0xff).toInt().ushr(4) and 0x1f)]
+        chars[24] = charMapping[(entropy[2].toInt() shl 5 or (entropy[3].toShort() and 0xff).toInt().ushr(7) and 0x1f)]
+        chars[25] = charMapping[((entropy[3].toShort() and 0xff).toInt().ushr(2) and 0x1f)]
+
+        return String(chars)
+    }
+}

--- a/src/main/kotlin/util/extensions.kt
+++ b/src/main/kotlin/util/extensions.kt
@@ -14,3 +14,5 @@ fun String.matchesWildcard(pattern: String): Boolean {
     if (mySuffix == suffix.substring(0, mySuffix.length)) return true
     return false
 }
+
+fun systemEpoch() = (System.currentTimeMillis() / 1000L).toInt()

--- a/src/main/kotlin/value/VFun.kt
+++ b/src/main/kotlin/value/VFun.kt
@@ -36,6 +36,8 @@ data class VFun(
         return null
     }
 
+    override fun execute(c: Context, args: List<Value>) = verbInvoke(c, args)
+
     fun verbInvoke(c: Context, args: List<Value>): Value {
         if ((args.size < argNames.size) || (args.size > argNames.size && args.size > 1))
             fail(E_RANGE, "lambda wants ${argNames.size} args but got ${args.size}")

--- a/src/main/kotlin/vm/Executable.kt
+++ b/src/main/kotlin/vm/Executable.kt
@@ -1,5 +1,6 @@
 package com.dlfsystems.vm
 
+import com.dlfsystems.app.Log
 import com.dlfsystems.value.VFun
 import com.dlfsystems.value.VObj
 import com.dlfsystems.value.Value
@@ -31,6 +32,7 @@ interface Executable {
                 address = it - offset
             ) } ?: word
         }
+        Log.d("LAMBDA CODE:\n${lambdaCode.dumpText()}\n")
         return VFun(lambdaCode, symbols, blocks, vThis, args, withVars)
     }
 

--- a/src/main/kotlin/vm/Executable.kt
+++ b/src/main/kotlin/vm/Executable.kt
@@ -14,6 +14,8 @@ interface Executable {
     val symbols: Map<String, Int>
     val blocks: List<Block>
 
+    fun execute(c: Context, args: List<Value>): Value
+
     fun getLambda(
         block: Int,
         vThis: VObj,

--- a/src/main/kotlin/vm/Opcode.kt
+++ b/src/main/kotlin/vm/Opcode.kt
@@ -60,6 +60,7 @@ enum class Opcode(val argCount: Int = 0) {
     O_CALL(1),
 
     // Call fun with arg1 name and arg2 stack args.
+    // Push result.
     O_FUNCALL(2),
 
     // Push variable with ID arg1.
@@ -134,5 +135,8 @@ enum class Opcode(val argCount: Int = 0) {
 
     // Push the addition of pop0, pop1, and value arg1.
     O_CONCAT(1),
+
+    // Call fun but do not push result.
+    O_FUNVOKE(2),
 
 }

--- a/src/main/kotlin/vm/Opcode.kt
+++ b/src/main/kotlin/vm/Opcode.kt
@@ -50,6 +50,12 @@ enum class Opcode(val argCount: Int = 0) {
     // Throw E_USER with pop0 as message.
     O_FAIL,
 
+    // Suspend for pop0 seconds.
+    O_SUSPEND,
+
+    // Fork pop0 VFun pop1 seconds in the future.
+    O_FORK,
+
     // Call verb with arg1 stack args.
     O_CALL(1),
 

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -212,7 +212,10 @@ class VM(val exe: Executable) {
                 }
                 O_FORK -> {
                     val (a2, a1) = popTwo()
-                    MCP.schedule(a2 as VFun, (a1 as VInt).v)
+                    MCP.schedule(Context(c.connection).apply {
+                        vThis = c.vThis
+                        vUser = c.vUser
+                    }, a2 as VFun, listOf(), (a1 as VInt).v)
                 }
 
                 // Variable ops

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -54,7 +54,7 @@ class VM(val exe: Executable) {
         try {
             return executeCode(c)
         } catch (e: Exception) {
-            throw (e as? VMException ?: VMException(E_SYS, e.message ?: e.stackTraceToString()))
+            throw (e as? VMException ?: VMException(E_SYS, "${e.message} (mem $pc)\n${e.stackTraceToString()}"))
                 .withLocation(lineNum, charNum)
         }
     }

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -2,6 +2,8 @@
 
 package com.dlfsystems.vm
 
+import com.dlfsystems.server.MCP
+import com.dlfsystems.server.SuspendException
 import com.dlfsystems.server.Yegg
 import com.dlfsystems.value.Value
 import com.dlfsystems.vm.Opcode.*
@@ -206,11 +208,11 @@ class VM(val exe: Executable) {
 
                 O_SUSPEND -> {
                     val a = pop()
-
+                    throw SuspendException((a as VInt).v)
                 }
                 O_FORK -> {
                     val (a2, a1) = popTwo()
-
+                    MCP.schedule(a2 as VFun, (a1 as VInt).v)
                 }
 
                 // Variable ops

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -81,7 +81,7 @@ class VM(val exe: Executable) {
             when (word.opcode) {
 
                 O_DISCARD -> {
-                    pop()
+                    if (stack.isNotEmpty()) pop()
                 }
 
                 // Value ops
@@ -153,7 +153,7 @@ class VM(val exe: Executable) {
                     if (addr >= 0) pc = addr else return VVoid  // Unresolved jump dest means end-of-code
                 }
                 O_RETURN -> {
-                    if (stack.isEmpty()) fail(E_SYS, "no return value on stack!")
+                    if (stack.isEmpty()) return VVoid
                     if (stack.size > 1) fail(E_SYS, "stack polluted on return!  ${dumpStack()}")
                     return pop()
                 }

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -202,6 +202,17 @@ class VM(val exe: Executable) {
                     }
                 }
 
+                // Task ops
+
+                O_SUSPEND -> {
+                    val a = pop()
+
+                }
+                O_FORK -> {
+                    val (a2, a1) = popTwo()
+
+                }
+
                 // Variable ops
 
                 O_GETVAR -> {

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -188,7 +188,7 @@ class VM(val exe: Executable) {
                         ticksLeft = c.ticksLeft
                     } else fail(E_VERBNF, "verb name must be string")
                 }
-                O_FUNCALL -> {
+                O_FUNCALL, O_FUNVOKE -> {
                     val name = (next().value as VString).v
                     val argCount = next().intFromV
                     val args = mutableListOf<Value>()
@@ -204,7 +204,7 @@ class VM(val exe: Executable) {
                         } ?: Yegg.world.sys.callVerb(c, name, args)?.also {
                             result = it
                         } ?: fail(E_VARNF, "no such fun or variable")
-                        result?.also { push(it) }
+                        result?.also { if (word.opcode == O_FUNCALL) push(it) }
                     }
                 }
 

--- a/src/main/kotlin/world/trait/SysTrait.kt
+++ b/src/main/kotlin/world/trait/SysTrait.kt
@@ -3,6 +3,7 @@ package com.dlfsystems.world.trait
 import com.dlfsystems.app.Log
 import com.dlfsystems.server.Command
 import com.dlfsystems.server.Yegg
+import com.dlfsystems.util.systemEpoch
 import com.dlfsystems.value.*
 import com.dlfsystems.vm.Context
 import com.dlfsystems.world.Obj
@@ -45,7 +46,7 @@ class SysTrait : Trait("sys") {
     }
 
     // $sys.time -> n
-    private fun propTime() = VInt((System.currentTimeMillis() / 1000L).toInt())
+    private fun propTime() = VInt(systemEpoch())
 
     // $sys.connectedUsers -> [#obj, #obj...]
     private fun propConnectedUsers() = VList(Yegg.connectedUsers.keys.map { it.vThis }.toMutableList())

--- a/src/main/kotlin/world/trait/Verb.kt
+++ b/src/main/kotlin/world/trait/Verb.kt
@@ -29,6 +29,8 @@ class Verb(
         Log.i("programmed $name with code ${code.dumpText()}")
     }
 
+    override fun execute(c: Context, args: List<Value>) = call(c, c.vThis, args)
+
     fun call(
         c: Context, vThis: VObj,
         args: List<Value>,


### PR DESCRIPTION
This PR implements fork (secondsExpr) { code... } .  It also parses 'suspend (secondsExpr)' but does not fully implement it just yet.

To do this we had to do some lifting:

- Added 'fork' and 'suspend' to Parser and related AST nodes.
- Added MCP, the scheduling object.  You can schedule() an Executable for seconds in the future.  All verb code execution should now happen via MCP tasks.
- Changed Connection.runCommand() to schedule the matched command verb with MCP, rather than executing it.
- Implement O_FORK to schedule a VFun with MCP.

And a few ancillary fixes:

- Along the way I found that my stack management was sloppy, and had to tweak how I'm managing return values in a few spots.
- Added some debug output and switchable compiler optimizing.

To complete this, I need to make fork an expression which returns its taskID to be cancelled later, but for clarity I'm saving that for a followup PR.
