### PR TITLE
Fork as expression, and VTask

### DIFF
--- a/src/main/kotlin/compiler/Coder.kt
+++ b/src/main/kotlin/compiler/Coder.kt
@@ -210,6 +210,11 @@ class Coder(val ast: Node) {
                     value(args[0].value!!)
                 }
 
+                ?: consume(O_VAL, null, O_GETTRAIT)?.also { args ->
+                    code(O_VTRAIT)
+                    value(args[0].value!!)
+                }
+
 
                 // If nothing matched, copy and continue
                 ?: run {

--- a/src/main/kotlin/compiler/Coder.kt
+++ b/src/main/kotlin/compiler/Coder.kt
@@ -190,6 +190,26 @@ class Coder(val ast: Node) {
                     value(args[1].value!!)
                 }
 
+                // O_VAL O_CALL O_DISCARD => O_VCVOKE
+                ?: consume(O_VAL, null, O_CALL, null, O_DISCARD)?.also { args ->
+                    code(O_VCVOKE)
+                    value(args[1].value!!) // write O_CALL arg first
+                    value(args[0].value!!)
+                }
+
+                // O_VAL O_CALL => O_VCALL
+                ?: consume(O_VAL, null, O_CALL, null)?.also { args ->
+                    code(O_VCALL)
+                    value(args[1].value!!) // write O_CALL arg first
+                    value(args[0].value!!)
+                }
+
+                // O_VAL O_GETPROP => O_VGETPROP
+                ?: consume(O_VAL, null, O_GETPROP)?.also { args ->
+                    code(O_VGETPROP)
+                    value(args[0].value!!)
+                }
+
 
                 // If nothing matched, copy and continue
                 ?: run {

--- a/src/main/kotlin/compiler/Coder.kt
+++ b/src/main/kotlin/compiler/Coder.kt
@@ -185,14 +185,14 @@ class Coder(val ast: Node) {
 
                 // O_FUNCALL O_DISCARD => O_FUNVOKE
                 ?: consume(O_FUNCALL, null, null, O_DISCARD)?.also { args ->
-                    code(O_FUNVOKE)
+                    code(O_FUNCALLST)
                     value(args[0].value!!)
                     value(args[1].value!!)
                 }
 
                 // O_VAL O_CALL O_DISCARD => O_VCVOKE
                 ?: consume(O_VAL, null, O_CALL, null, O_DISCARD)?.also { args ->
-                    code(O_VCVOKE)
+                    code(O_VCALLST)
                     value(args[1].value!!) // write O_CALL arg first
                     value(args[0].value!!)
                 }
@@ -210,7 +210,7 @@ class Coder(val ast: Node) {
                     value(args[0].value!!)
                 }
 
-                ?: consume(O_VAL, null, O_GETTRAIT)?.also { args ->
+                ?: consume(O_VAL, null, O_TRAIT)?.also { args ->
                     code(O_VTRAIT)
                     value(args[0].value!!)
                 }

--- a/src/main/kotlin/compiler/ast/N_EXPR.kt
+++ b/src/main/kotlin/compiler/ast/N_EXPR.kt
@@ -136,3 +136,16 @@ class N_WHEN(val subject: N_EXPR?, val options: List<Pair<N_EXPR?, Node>>, val a
         coder.setForwardJump(this, "end")
     }
 }
+
+// fork <expr> { block }
+// Returns a VTask with the forked task ID.
+class N_FORK(val seconds: N_EXPR, val function: N_LITERAL_FUN): N_EXPR() {
+    override fun toText() = "fork ($seconds) $function"
+    override fun kids() = listOf(seconds, function)
+
+    override fun code(coder: Coder) {
+        seconds.code(coder)
+        function.code(coder)
+        coder.code(this, O_FORK)
+    }
+}

--- a/src/main/kotlin/compiler/ast/N_IDENTIFIER.kt
+++ b/src/main/kotlin/compiler/ast/N_IDENTIFIER.kt
@@ -123,6 +123,6 @@ class N_TRAITREF(val expr: N_EXPR): N_EXPR() {
 
     override fun code(coder: Coder) {
         expr.code(coder)
-        coder.code(this, O_GETTRAIT)
+        coder.code(this, O_TRAIT)
     }
 }

--- a/src/main/kotlin/compiler/ast/N_STATEMENT.kt
+++ b/src/main/kotlin/compiler/ast/N_STATEMENT.kt
@@ -201,14 +201,3 @@ class N_SUSPEND(val seconds: N_EXPR): N_STATEMENT() {
         coder.code(this, O_SUSPEND)
     }
 }
-
-class N_FORK(val seconds: N_EXPR, val function: N_LITERAL_FUN): N_STATEMENT() {
-    override fun toText() = "fork ($seconds) $function"
-    override fun kids() = listOf(seconds, function)
-
-    override fun code(coder: Coder) {
-        seconds.code(coder)
-        function.code(coder)
-        coder.code(this, O_FORK)
-    }
-}

--- a/src/main/kotlin/server/MCP.kt
+++ b/src/main/kotlin/server/MCP.kt
@@ -17,7 +17,7 @@ object MCP {
     private var job: Job? = null
 
     private val coroutineScope = CoroutineScope(
-    SupervisorJob() +
+        SupervisorJob() +
         Dispatchers.Default.limitedParallelism(1) +
         CoroutineName("Yegg MCP thread")
     )

--- a/src/main/kotlin/server/MCP.kt
+++ b/src/main/kotlin/server/MCP.kt
@@ -28,9 +28,10 @@ SupervisorJob() +
         exe: Executable,
         args: List<Value>,
         secondsInFuture: Int = 0
-    ) {
+    ): TaskID {
         val task = Task(systemEpoch() + secondsInFuture, c, exe, args)
         taskMap[task.id] = task
+        return task.id
     }
 
     // Cancel a scheduled task.

--- a/src/main/kotlin/server/MCP.kt
+++ b/src/main/kotlin/server/MCP.kt
@@ -16,6 +16,12 @@ object MCP {
     private val taskMap = TreeMap<TaskID, Task>()
     private var job: Job? = null
 
+    private val coroutineScope = CoroutineScope(
+SupervisorJob() +
+        Dispatchers.Default.limitedParallelism(1) +
+        CoroutineName("Yegg MCP thread")
+    )
+
     // Schedule an executable to run some seconds in the future.
     fun schedule(
         c: Context,
@@ -27,14 +33,30 @@ object MCP {
         taskMap[task.id] = task
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
+    // Cancel a scheduled task.
+    fun cancel(taskID: TaskID) { taskMap.remove(taskID) }
+
+    // Move a scheduled task to immediate execution.
+    fun resume(taskID: TaskID) {
+        taskMap[taskID]?.also { task ->
+            taskMap.remove(taskID)
+            val newTask = Task(systemEpoch(), task.c, task.exe, task.args)
+            taskMap[newTask.id] = newTask
+        } ?: throw IllegalArgumentException("Task $taskID does not exist")
+    }
+
+    // Is the given taskID a valid scheduled task?
+    fun isValidTask(taskID: TaskID) = taskMap.containsKey(taskID)
+
+    // Start processing all queued tasks.
     fun start() {
         if (job?.isActive == true) throw IllegalStateException("Already started")
-        job = GlobalScope.launch {
+        job = coroutineScope.launch {
             runTasks()
         }
     }
 
+    // Stop processing queued tasks.
     fun stop() {
         job?.cancel()
     }

--- a/src/main/kotlin/server/MCP.kt
+++ b/src/main/kotlin/server/MCP.kt
@@ -17,7 +17,7 @@ object MCP {
     private var job: Job? = null
 
     private val coroutineScope = CoroutineScope(
-SupervisorJob() +
+    SupervisorJob() +
         Dispatchers.Default.limitedParallelism(1) +
         CoroutineName("Yegg MCP thread")
     )

--- a/src/main/kotlin/server/Task.kt
+++ b/src/main/kotlin/server/Task.kt
@@ -4,9 +4,11 @@ import com.dlfsystems.util.TaskIDGenerator
 import com.dlfsystems.value.Value
 import com.dlfsystems.vm.Context
 import com.dlfsystems.vm.Executable
+import kotlinx.serialization.Serializable
 import java.lang.Comparable
 
 
+@Serializable
 data class TaskID(val id: String): Comparable<TaskID> {
     override fun toString() = id
     override fun compareTo(other: TaskID) = id.compareTo(other.id)

--- a/src/main/kotlin/server/Yegg.kt
+++ b/src/main/kotlin/server/Yegg.kt
@@ -109,6 +109,7 @@ object Yegg {
     }
 
     fun shutdownServer() {
+        MCP.stop()
         exitProcess(0)
     }
 }

--- a/src/main/kotlin/value/VTask.kt
+++ b/src/main/kotlin/value/VTask.kt
@@ -1,0 +1,55 @@
+package com.dlfsystems.value
+
+import com.dlfsystems.server.MCP
+import com.dlfsystems.server.TaskID
+import com.dlfsystems.server.Yegg
+import com.dlfsystems.vm.Context
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+@SerialName("VTask")
+data class VTask(val v: TaskID): Value() {
+
+    @SerialName("yType")
+    override val type = Type.TASK
+
+    override fun toString() = "<task:$v>"
+    override fun asString() = toString()
+
+    // Valid tasks are true
+    override fun isTrue() = MCP.isValidTask(v)
+
+    // Tasks compare by ID, which compares by scheduled time
+    override fun cmpEq(a2: Value) = (a2 is VTask && v == a2.v)
+    override fun cmpGe(a2: Value) = (a2 is VTask && v >= a2.v)
+    override fun cmpGt(a2: Value) = (a2 is VTask && v > a2.v)
+
+    override fun getProp(name: String): Value? {
+        when (name) {
+            "isValid" -> return if (MCP.isValidTask(v)) Yegg.vTrue else Yegg.vFalse
+        }
+        return null
+    }
+
+    override fun callVerb(c: Context, name: String, args: List<Value>): Value? {
+        when (name) {
+            "cancel" -> return verbCancel(args)
+            "resume" -> return verbResume(args)
+        }
+        return null
+    }
+
+    private fun verbCancel(args: List<Value>): Value {
+        requireArgCount(args, 0, 0)
+        MCP.cancel(v)
+        return VVoid
+    }
+
+    private fun verbResume(args: List<Value>): Value {
+        requireArgCount(args, 0, 0)
+        MCP.resume(v)
+        return VVoid
+    }
+
+}

--- a/src/main/kotlin/value/Value.kt
+++ b/src/main/kotlin/value/Value.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 sealed class Value {
-    enum class Type { VOID, BOOL, INT, FLOAT, STRING, LIST, MAP, OBJ, TRAIT, FUN }
+    enum class Type { VOID, BOOL, INT, FLOAT, STRING, LIST, MAP, OBJ, TRAIT, FUN, TASK }
 
     @SerialName("yType")
     abstract val type: Type

--- a/src/main/kotlin/vm/Opcode.kt
+++ b/src/main/kotlin/vm/Opcode.kt
@@ -54,6 +54,7 @@ enum class Opcode(val argCount: Int = 0) {
     O_SUSPEND,
 
     // Fork pop0 VFun pop1 seconds in the future.
+    // Push VTask with taskID of forked task.
     O_FORK,
 
     // Call verb with arg1 stack args.

--- a/src/main/kotlin/vm/Opcode.kt
+++ b/src/main/kotlin/vm/Opcode.kt
@@ -96,7 +96,7 @@ enum class Opcode(val argCount: Int = 0) {
     O_SETPROP,
 
     // Push trait named by string pop0.
-    O_GETTRAIT,
+    O_TRAIT,
 
     // Push negation of pop0.
     O_NEGATE,
@@ -137,11 +137,11 @@ enum class Opcode(val argCount: Int = 0) {
     // Push the addition of pop0, pop1, and value arg1.
     O_CONCAT(1),
 
-    // Call fun but do not push result.
-    O_FUNVOKE(2),
+    // Call fun as statement (do not push result).
+    O_FUNCALLST(2),
 
-    // Call literal-named verb but do not push result.
-    O_VCVOKE(2),
+    // Call literal-named verb as statement (do not push result).
+    O_VCALLST(2),
 
     // Call literal-named verb.
     O_VCALL(2),

--- a/src/main/kotlin/vm/Opcode.kt
+++ b/src/main/kotlin/vm/Opcode.kt
@@ -140,4 +140,13 @@ enum class Opcode(val argCount: Int = 0) {
     // Call fun but do not push result.
     O_FUNVOKE(2),
 
+    // Call literal-named verb but do not push result.
+    O_VCVOKE(2),
+
+    // Call literal-named verb.
+    O_VCALL(2),
+
+    // Get literal-named property.
+    O_VGETPROP(1),
+
 }

--- a/src/main/kotlin/vm/Opcode.kt
+++ b/src/main/kotlin/vm/Opcode.kt
@@ -149,4 +149,7 @@ enum class Opcode(val argCount: Int = 0) {
     // Get literal-named property.
     O_VGETPROP(1),
 
+    // Get literal-named trait.
+    O_VTRAIT(1),
+
 }

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -216,10 +216,11 @@ class VM(val exe: Executable) {
                 }
                 O_FORK -> {
                     val (a2, a1) = popTwo()
-                    MCP.schedule(Context(c.connection).apply {
+                    val taskID = MCP.schedule(Context(c.connection).apply {
                         vThis = c.vThis
                         vUser = c.vUser
                     }, a2 as VFun, listOf(), (a1 as VInt).v)
+                    push(VTask(taskID))
                 }
 
                 // Variable ops

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -174,7 +174,7 @@ class VM(val exe: Executable) {
 
                 // Verb ops
 
-                O_CALL, O_VCALL, O_VCVOKE -> {
+                O_CALL, O_VCALL, O_VCALLST -> {
                     val argCount = next().intFromV
                     val a2 = if (word.opcode == O_CALL) pop() else next().value
                     val a1 = pop()
@@ -184,13 +184,13 @@ class VM(val exe: Executable) {
                         c.ticksLeft = ticksLeft
                         c.callsLeft--
                         a1.callVerb(c, a2.v, args)?.also {
-                            if (word.opcode != O_VCVOKE) push(it)
+                            if (word.opcode != O_VCALLST) push(it)
                         } ?: fail(E_VERBNF, "verb not found")
                         c.callsLeft++
                         ticksLeft = c.ticksLeft
                     } else fail(E_VERBNF, "verb name must be string")
                 }
-                O_FUNCALL, O_FUNVOKE -> {
+                O_FUNCALL, O_FUNCALLST -> {
                     val name = (next().value as VString).v
                     val argCount = next().intFromV
                     val args = mutableListOf<Value>()
@@ -206,7 +206,7 @@ class VM(val exe: Executable) {
                         } ?: Yegg.world.sys.callVerb(c, name, args)?.also {
                             result = it
                         } ?: fail(E_VARNF, "no such fun or variable")
-                        result?.also { if (word.opcode == O_FUNCALL) push(it) }
+                        result?.also { if (word.opcode != O_FUNCALLST) push(it) }
                     }
                 }
 
@@ -287,7 +287,7 @@ class VM(val exe: Executable) {
                     if (!a2.setProp((a3 as VString).v, a1))
                         fail(E_PROPNF, "property not found")
                 }
-                O_GETTRAIT, O_VTRAIT -> {
+                O_TRAIT, O_VTRAIT -> {
                     val a1 = if (word.opcode == O_VTRAIT) next().value!! else pop()
                     if (a1 is VString) {
                         Yegg.world.getTrait(a1.v)?.also { push(it.vTrait) }

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -287,8 +287,8 @@ class VM(val exe: Executable) {
                     if (!a2.setProp((a3 as VString).v, a1))
                         fail(E_PROPNF, "property not found")
                 }
-                O_GETTRAIT -> {
-                    val a1 = pop()
+                O_GETTRAIT, O_VTRAIT -> {
+                    val a1 = if (word.opcode == O_VTRAIT) next().value!! else pop()
                     if (a1 is VString) {
                         Yegg.world.getTrait(a1.v)?.also { push(it.vTrait) }
                             ?: fail (E_TRAITNF, "trait not found")


### PR DESCRIPTION
Adds VTask, a new Value type, which represents a taskID.  It provides a property .isValid, and the verbs .cancel() and .resume().

The 'fork' keyword is now parsed as an expression, so its return VTask can be captured and used.  (It still works fine as a bare expression-statement.)

```
notifyConn("Let's fork some tasks!")
task1 = fork 30 { notifyConn("FAILURE") }
task2 = fork 30 { notifyConn("RESUMED at ${$sys.time}") }
fork (2) {
	notifyConn("Now we cancel one and resume the other.")
	task1.cancel()
	task2.resume()
}
notifyConn("Good luck.  Time is ${$sys.time}")
```

```
< Let's fork some tasks!
< Good luck.  Time is 1747094215
< Now we cancel one and resume the other.
< RESUMED at 1747094217
```

and just for fun here's the lambda code that went onto those tasks' VFuns:

```
DEBUG: LAMBDA CODE:
<0> O_VAL "FAILURE"
<2> O_FUNVOKE "notifyConn" 1
<5> O_RETURN

DEBUG: LAMBDA CODE:
<0> O_VAL "RESUMED at "
<2> O_VAL "sys"
<4> O_GETTRAIT
<5> O_VGETPROP "time"
<7> O_ADD
<8> O_FUNVOKE "notifyConn" 1
<11> O_RETURN

DEBUG: LAMBDA CODE:
<0> O_VAL "Now we cancel one and resume the other."
<2> O_FUNVOKE "notifyConn" 1
<5> O_GETVAR 1
<7> O_VCVOKE 0 "cancel"
<10> O_GETVAR 2
<12> O_VCVOKE 0 "resume"
<15> O_RETURN
```

(Also added 4 new optimizer opcodes, not necessary but I noticed them while testing.)
