### PR TITLE
Null-safe references

### DIFF
--- a/src/main/kotlin/compiler/Coder.kt
+++ b/src/main/kotlin/compiler/Coder.kt
@@ -111,7 +111,7 @@ class Coder(val ast: Node) {
     fun setForwardJump(name: String) {
         val dest = mem.size
         val fullname = "$name${writer.id}"
-        forwardJumps[fullname]!!.forEach { loc ->
+        forwardJumps[fullname]?.forEach { loc ->
             mem[loc].address = dest
         }
         forwardJumps.remove(fullname)

--- a/src/main/kotlin/compiler/ast/expr/ref/N_PROPREF.kt
+++ b/src/main/kotlin/compiler/ast/expr/ref/N_PROPREF.kt
@@ -3,10 +3,17 @@ package com.dlfsystems.yegg.compiler.ast.expr.ref
 import com.dlfsystems.yegg.compiler.Coder
 import com.dlfsystems.yegg.compiler.ast.expr.N_EXPR
 import com.dlfsystems.yegg.compiler.ast.expr.identifier.N_IDENTIFIER
+import com.dlfsystems.yegg.vm.Opcode.O_DISCARD
 import com.dlfsystems.yegg.vm.Opcode.O_GETPROP
+import com.dlfsystems.yegg.vm.Opcode.O_IFNULL
+import com.dlfsystems.yegg.vm.Opcode.O_JUMP
 import com.dlfsystems.yegg.vm.Opcode.O_SETPROP
 
-class N_PROPREF(val left: N_EXPR, val right: N_EXPR): N_EXPR() {
+class N_PROPREF(
+    val isNullsafe: Boolean,
+    val left: N_EXPR,
+    val right: N_EXPR
+): N_EXPR() {
 
     override fun toString() = "($left.$right)"
     override fun kids() = listOf(left, right)
@@ -15,14 +22,28 @@ class N_PROPREF(val left: N_EXPR, val right: N_EXPR): N_EXPR() {
 
     override fun code(c: Coder) = with (c.use(this)) {
         code(left)
+        if (isNullsafe) {
+            opcode(O_IFNULL)
+            jumpForward("skipref")
+        }
         code(right)
         opcode(O_GETPROP)
+        setForwardJump("skipref")
     }
 
     override fun codeAssign(c: Coder) = with (c.use(this)) {
         code(left)
+        if (isNullsafe) {
+            opcode(O_IFNULL)
+            jumpForward("skipref")
+        }
         code(right)
         opcode(O_SETPROP)
+        opcode(O_JUMP)
+        jumpForward("skipNullpop")
+        setForwardJump("skipref")
+        opcode(O_DISCARD)
+        setForwardJump("skipNullpop")
     }
 
 }

--- a/src/main/kotlin/compiler/ast/expr/ref/N_VERBREF.kt
+++ b/src/main/kotlin/compiler/ast/expr/ref/N_VERBREF.kt
@@ -3,8 +3,10 @@ package com.dlfsystems.yegg.compiler.ast.expr.identifier
 import com.dlfsystems.yegg.compiler.Coder
 import com.dlfsystems.yegg.compiler.ast.expr.N_EXPR
 import com.dlfsystems.yegg.vm.Opcode.O_CALL
+import com.dlfsystems.yegg.vm.Opcode.O_IFNULL
 
 class N_VERBREF(
+    val isNullsafe: Boolean,
     val left: N_EXPR,
     val right: N_EXPR,
     val args: List<N_EXPR>
@@ -16,11 +18,16 @@ class N_VERBREF(
     override fun identify() { (right as? N_IDENTIFIER)?.markAsVerb() }
 
     override fun code(c: Coder) = with (c.use(this)) {
-        args.forEach { code(it) }
         code(left)
+        if (isNullsafe) {
+            opcode(O_IFNULL)
+            jumpForward("skipref")
+        }
+        args.forEach { code(it) }
         code(right)
         opcode(O_CALL)
         value(args.size)
+        setForwardJump("skipref")
     }
 
 }

--- a/src/main/kotlin/server/mcp/Task.kt
+++ b/src/main/kotlin/server/mcp/Task.kt
@@ -117,7 +117,7 @@ class Task(
         return VVoid
     }
 
-    private fun push(vThis: VObj, exe: Executable, args: List<Value>) {
+    private fun push(vThis: VObj?, exe: Executable, args: List<Value>) {
         exe.jitCompile()
         stack.addFirst(VM(this, vThis, exe, args))
     }

--- a/src/main/kotlin/value/VNull.kt
+++ b/src/main/kotlin/value/VNull.kt
@@ -13,6 +13,7 @@ data object VNull: Value() {
 
     override fun toString() = "null"
 
+    override fun isNull() = true
     override fun negate() = Yegg.vTrue
     override fun cmpEq(a2: Value) = a2 == this
     override fun cmpGt(a2: Value) = a2 != this

--- a/src/main/kotlin/value/VObj.kt
+++ b/src/main/kotlin/value/VObj.kt
@@ -28,6 +28,7 @@ data class VObj(val v: Obj.ID?): Value() {
     override fun asString() = "OBJ" // TODO: use name
 
     override fun isTrue() = v != null
+    override fun isNull() = !Yegg.world.objs.contains(v)
 
     override fun cmpEq(a2: Value) = (a2 is VObj) && (v == a2.v)
 

--- a/src/main/kotlin/value/Value.kt
+++ b/src/main/kotlin/value/Value.kt
@@ -19,10 +19,11 @@ sealed class Value {
     // String equivalent when added to a string.
     open fun asString(): String = toString()
 
-    // Is this value considered true/false/zero in code?
+    // Is this value considered true/false/zero/null in code?
     open fun isTrue(): Boolean = false
     fun isFalse(): Boolean = !isTrue()
     open fun isZero(): Boolean = false
+    open fun isNull(): Boolean = false
 
     // How many elements do I have for iteration?
     open fun iterableSize(): Int? = null

--- a/src/main/kotlin/vm/Opcode.kt
+++ b/src/main/kotlin/vm/Opcode.kt
@@ -40,6 +40,9 @@ enum class Opcode(val argCount: Int = 0) {
     // Jump to arg1 address if peek0 is non-null, otherwise pop the null.
     O_IFNON(1),
 
+    // Jump to arg1 address if peek0 is null.
+    O_IFNULL(1),
+
     // Jump to arg1 address.
     O_JUMP(1),
 

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -71,7 +71,7 @@ class VM(
             setVar(name, v)
         }
         setVar("args", VList.make(args))
-        setVar("this", c.vThis)
+        setVar("this", vThis)
         setVar("player", c.vPlayer)
     }
 

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -201,6 +201,10 @@ class VM(
                     val elseAddr = next().address!!
                     if (peek() == VNull) pop() else pc = elseAddr
                 }
+                O_IFNULL -> {
+                    val elseAddr = next().address!!
+                    if (peek() == VNull) pc = elseAddr
+                }
                 O_IFVAREQ -> {
                     val varID = next().intFromV
                     val elseAddr = next().address!!
@@ -249,8 +253,8 @@ class VM(
                 O_CALL, O_VCALL, O_VCALLST -> {
                     val argCount = next().intFromV
                     val name = (if (word.opcode == O_CALL) pop() else next().value!!).asString()
-                    val subj = pop()
                     val args = buildList { repeat(argCount) { add(0, pop()) } }
+                    val subj = pop()
                     // If static built-in verb, call directly without returning
                     subj.callStaticVerb(c, name, args)?.also {
                         if (word.opcode != O_VCALLST) push(it)

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -199,11 +199,11 @@ class VM(
                 }
                 O_IFNON -> {
                     val elseAddr = next().address!!
-                    if (peek() == VNull) pop() else pc = elseAddr
+                    if (peek().isNull()) pop() else pc = elseAddr
                 }
                 O_IFNULL -> {
                     val elseAddr = next().address!!
-                    if (peek() == VNull) pc = elseAddr
+                    if (peek().isNull()) pc = elseAddr
                 }
                 O_IFVAREQ -> {
                     val varID = next().intFromV

--- a/src/test/kotlin/NullTest.kt
+++ b/src/test/kotlin/NullTest.kt
@@ -49,6 +49,7 @@ class NullTest: YeggTest() {
             a2.weight = 7
             a3 = create($animal)
             a3.weight = 10
+            destroy(a1)
             for (x in [a1, a2, null, a3]) {
                 w = x?.weight ?: 666
                 size = x?.getSize() ?: 0
@@ -57,7 +58,7 @@ class NullTest: YeggTest() {
                 if ((x?.weight ?: 12) != 12) cnotify("OH NO!")
             }
         ""","""
-            4 and 12
+            666 and 0
             7 and 21
             666 and 0
             10 and 30

--- a/src/test/kotlin/NullTest.kt
+++ b/src/test/kotlin/NullTest.kt
@@ -34,4 +34,33 @@ class NullTest: YeggTest() {
             E_TYPE: INT is not STRING
         """)
     }
+
+    @Test
+    fun `Null-safe verb and prop refs`() = yeggTest {
+        run($$"""
+            createTrait("animal")
+            addProp($animal, "weight", 10)
+        """)
+        verb("animal", "getSize", "return this.weight * 3")
+        runForOutput($$"""
+            a1 = create($animal)
+            a1.weight = 4
+            a2 = create($animal)
+            a2.weight = 7
+            a3 = create($animal)
+            a3.weight = 10
+            for (x in [a1, a2, null, a3]) {
+                w = x?.weight ?: 666
+                size = x?.getSize() ?: 0
+                cnotify("$w and $size")
+                x?.weight = 12
+                if ((x?.weight ?: 12) != 12) cnotify("OH NO!")
+            }
+        ""","""
+            4 and 12
+            7 and 21
+            666 and 0
+            10 and 30
+        """)
+    }
 }


### PR DESCRIPTION
Allows expr?.prop / expr?.verb() references, which skip the reference when expr is null, and simply pass the null along.

For purposes of this syntax (and ?: elvis) an object value is considered null if it's invalid.  This isn't, like, clean language design or what have you, I guess, but it seems very convenient.